### PR TITLE
Qr code pages

### DIFF
--- a/src/main/client/package.json
+++ b/src/main/client/package.json
@@ -39,6 +39,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-icons": "4.3.1",
+    "react-qr-reader": "^2.2.1",
     "react-router-dom": "6",
     "react-scripts": "5.0.0",
     "web-vitals": "0.2.2"
@@ -50,6 +51,7 @@
     "@types/node": "17.0.8",
     "@types/react": "17.0.2",
     "@types/react-dom": "17.0.2",
+    "@types/react-qr-reader": "^2.1.4",
     "@typescript-eslint/eslint-plugin": "5.9.1",
     "@typescript-eslint/parser": "5.9.1",
     "eslint": "8.6.0",

--- a/src/main/client/src/App.tsx
+++ b/src/main/client/src/App.tsx
@@ -14,6 +14,7 @@ import { AchievementList } from './components/@pages/AchievementList'
 import { AchievementPage } from './components/@pages/AchievementPage'
 import { QRList } from 'components/@pages/QRList'
 import { QRScan } from 'components/@pages/QRScan'
+import { QRScanResult } from 'components/@pages/QRScanResult'
 
 export function App() {
   return (
@@ -47,6 +48,7 @@ export function App() {
                 <Route index element={<AchievementList />} />
               </Route>
               {/*QR*/}
+              <Route path="qr-scanned" element={<QRScanResult />}></Route>
               <Route path="qr">
                 <Route index element={<QRList />} />
                 <Route path="scan" element={<QRScan />}></Route>

--- a/src/main/client/src/App.tsx
+++ b/src/main/client/src/App.tsx
@@ -12,6 +12,7 @@ import { CommunityList } from './components/@pages/CommunityList'
 import { ProfilePage } from 'components/@pages/ProfilePage'
 import { AchievementList } from './components/@pages/AchievementList'
 import { AchievementPage } from './components/@pages/AchievementPage'
+import { QRList } from 'components/@pages/QRList'
 
 export function App() {
   return (
@@ -45,6 +46,10 @@ export function App() {
                 <Route index element={<AchievementList />} />
               </Route>
               {/*QR*/}
+              <Route path="qr">
+                <Route index element={<QRList />} />
+                <Route path="scan"></Route>
+              </Route>
             </Route>
           </Routes>
         </IndexLayout>

--- a/src/main/client/src/App.tsx
+++ b/src/main/client/src/App.tsx
@@ -13,6 +13,7 @@ import { ProfilePage } from 'components/@pages/ProfilePage'
 import { AchievementList } from './components/@pages/AchievementList'
 import { AchievementPage } from './components/@pages/AchievementPage'
 import { QRList } from 'components/@pages/QRList'
+import { QRScan } from 'components/@pages/QRScan'
 
 export function App() {
   return (
@@ -48,7 +49,7 @@ export function App() {
               {/*QR*/}
               <Route path="qr">
                 <Route index element={<QRList />} />
-                <Route path="scan"></Route>
+                <Route path="scan" element={<QRScan />}></Route>
               </Route>
             </Route>
           </Routes>

--- a/src/main/client/src/components/@commons/QRScanResultComponent.tsx
+++ b/src/main/client/src/components/@commons/QRScanResultComponent.tsx
@@ -7,7 +7,7 @@ interface QrScanResultProps {
   response: ScanResponseDTO
 }
 
-export const QrScanResultComponent: React.FC<QrScanResultProps> = ({ response }: QrScanResultProps) => {
+export const QRScanResultComponent: React.FC<QrScanResultProps> = ({ response }: QrScanResultProps) => {
   const renderIcon = () => {
     switch (response.status) {
       case ScanStatus.SCANNED:

--- a/src/main/client/src/components/@commons/QRScanResultComponent.tsx
+++ b/src/main/client/src/components/@commons/QRScanResultComponent.tsx
@@ -38,14 +38,14 @@ export const QRScanResultComponent: React.FC<QrScanResultProps> = ({ response }:
     <Box>
       {response.title && (
         <Center>
-          <Heading>{response.title}</Heading>
+          <Heading size="md">{response.title}</Heading>
         </Center>
       )}
       <Center p="40px" mt="4">
         {renderIcon()}
       </Center>
       <Center>
-        <Heading>{getInfoText()}</Heading>
+        <Heading size="md">{getInfoText()}</Heading>
       </Center>
     </Box>
   )

--- a/src/main/client/src/components/@commons/QrScanResultComponent.tsx
+++ b/src/main/client/src/components/@commons/QrScanResultComponent.tsx
@@ -1,0 +1,52 @@
+import { CheckCircleIcon, InfoIcon, WarningIcon, WarningTwoIcon } from '@chakra-ui/icons'
+import { Box, Center, Heading } from '@chakra-ui/react'
+import React from 'react'
+import { ScanResponseDTO, ScanStatus } from 'types/dto/token'
+
+interface QrScanResultProps {
+  response: ScanResponseDTO
+}
+
+export const QrScanResultComponent: React.FC<QrScanResultProps> = ({ response }: QrScanResultProps) => {
+  const renderIcon = () => {
+    switch (response.status) {
+      case ScanStatus.SCANNED:
+        return <CheckCircleIcon color="brand.500" boxSize="120px" />
+      case ScanStatus.ALREADY_SCANNED:
+        return <InfoIcon color="orange.500" boxSize="120px" />
+      case ScanStatus.WRONG:
+        return <WarningTwoIcon color="red.500" boxSize="120px" />
+      default:
+        return <WarningIcon color="red.600" boxSize="120px" />
+    }
+  }
+
+  const getInfoText = () => {
+    switch (response.status) {
+      case ScanStatus.SCANNED:
+        return 'Állomás lepecsételve'
+      case ScanStatus.ALREADY_SCANNED:
+        return 'Ezt a kódot már egyszer beolvastad'
+      case ScanStatus.WRONG:
+        return 'Ez a QR-kód nem jó a pontgyűjtéshez'
+      default:
+        return 'Hibás státusz kód'
+    }
+  }
+
+  return (
+    <Box>
+      {response.title && (
+        <Center>
+          <Heading>{response.title}</Heading>
+        </Center>
+      )}
+      <Center p="40px" mt="4">
+        {renderIcon()}
+      </Center>
+      <Center>
+        <Heading>{getInfoText()}</Heading>
+      </Center>
+    </Box>
+  )
+}

--- a/src/main/client/src/components/@commons/StampComponent.tsx
+++ b/src/main/client/src/components/@commons/StampComponent.tsx
@@ -9,12 +9,12 @@ interface StampComponentProps {
 
 export const StampComponent: React.FC<StampComponentProps> = ({ title, type }: StampComponentProps) => {
   return (
-    <Box maxW={'md'} minW={['100%', 'md']} borderRadius={'lg'} boxShadow="lg" bg="brand.100">
+    <Box maxW="md" minW={['100%', 'md']} borderRadius="lg" boxShadow="lg" bg="brand.100">
       <Flex>
-        <Center bg={'brand.300'} padding="2" borderStartRadius={'lg'}>
+        <Center bg="brand.300" padding="2" borderStartRadius="lg">
           <Icon as={FaStamp} boxSize="2em" fontSize="3xl" color="black" />
         </Center>
-        <Center width="100%" paddingStart={'3'} textAlign="center">
+        <Center width="100%" paddingStart="3" textAlign="center">
           <Stat>
             <StatLabel color="black" fontSize="xl">
               {title}

--- a/src/main/client/src/components/@commons/StampComponent.tsx
+++ b/src/main/client/src/components/@commons/StampComponent.tsx
@@ -1,0 +1,28 @@
+import { Box, Center, Flex, Icon, Stat, StatHelpText, StatLabel } from '@chakra-ui/react'
+import React from 'react'
+import { FaStamp } from 'react-icons/fa'
+
+interface StampComponentProps {
+  title?: string
+  type: string
+}
+
+export const StampComponent: React.FC<StampComponentProps> = ({ title, type }: StampComponentProps) => {
+  return (
+    <Box maxW={'md'} minW={['100%', 'md']} borderRadius={'lg'} boxShadow="lg" bg="brand.100">
+      <Flex>
+        <Center bg={'brand.300'} padding="2" borderStartRadius={'lg'}>
+          <Icon as={FaStamp} boxSize="2em" fontSize="3xl" color="black" />
+        </Center>
+        <Center width="100%" paddingStart={'3'} textAlign="center">
+          <Stat>
+            <StatLabel color="black" fontSize="xl">
+              {title}
+            </StatLabel>
+            <StatHelpText color="gray.800">{type}</StatHelpText>
+          </Stat>
+        </Center>
+      </Flex>
+    </Box>
+  )
+}

--- a/src/main/client/src/components/@pages/QRList.tsx
+++ b/src/main/client/src/components/@pages/QRList.tsx
@@ -39,7 +39,7 @@ export const QRList: React.FC = (props) => {
 
       <Progress hasStripe colorScheme="brand" value={(100 * token_response.length) / 5} />
       <Heading as="h4" size="md">
-        Amhol eddig jártál
+        Ahol eddig jártál
       </Heading>
       <Stack spacing="5" alignItems={'center'}>
         {token_response.map((token, i) => {

--- a/src/main/client/src/components/@pages/QRList.tsx
+++ b/src/main/client/src/components/@pages/QRList.tsx
@@ -1,10 +1,11 @@
 import { Page } from '../@layout/Page'
 import React from 'react'
-import { Heading, Button, Progress, Stack, Icon, Center, Flex, Box, Stat, StatHelpText, StatLabel } from '@chakra-ui/react'
-import { FaQrcode, FaStamp } from 'react-icons/fa'
+import { Heading, Button, Progress, Stack } from '@chakra-ui/react'
+import { FaQrcode } from 'react-icons/fa'
 import { TokenDTO } from 'types/dto/token'
 import { Paragraph } from 'components/@commons/Basics'
 import { useNavigate } from 'react-router-dom'
+import { StampComponent } from 'components/@commons/StampComponent'
 
 export const QRList: React.FC = (props) => {
   //Mock data for tokens
@@ -43,21 +44,7 @@ export const QRList: React.FC = (props) => {
       </Heading>
       <Stack spacing="5" alignItems={'center'}>
         {token_response.map((token, i) => {
-          return (
-            <Box key={i} maxW={'md'} minW={'md'} borderWidth="1px" borderRadius={'lg'} boxShadow="lg" bg="brand.100">
-              <Flex>
-                <Center bg={'brand.300'} padding="2">
-                  <Icon as={FaStamp} boxSize="2em" fontSize="3xl" />
-                </Center>
-                <Center width="100%" paddingStart={'3'} textAlign="center">
-                  <Stat>
-                    <StatLabel fontSize="xl">{token.title}</StatLabel>
-                    <StatHelpText>{token.type}</StatHelpText>
-                  </Stat>
-                </Center>
-              </Flex>
-            </Box>
-          )
+          return <StampComponent key={i} title={token.title} type={token.type}></StampComponent>
         })}
       </Stack>
     </Page>

--- a/src/main/client/src/components/@pages/QRList.tsx
+++ b/src/main/client/src/components/@pages/QRList.tsx
@@ -46,7 +46,7 @@ export const QRList: React.FC = (props) => {
       </Paragraph>
 
       <ButtonGroup>
-        <Button colorScheme={'brand'} leftIcon={<FaQrcode />} onClick={scanEventHandler}>
+        <Button colorScheme="brand" leftIcon={<FaQrcode />} onClick={scanEventHandler}>
           QR kód beolvasása
         </Button>
       </ButtonGroup>

--- a/src/main/client/src/components/@pages/QRList.tsx
+++ b/src/main/client/src/components/@pages/QRList.tsx
@@ -1,0 +1,58 @@
+import { Page } from '../@layout/Page'
+import React from 'react'
+import { Heading, Button, Progress, Stack, Icon, Center, Flex, Box, Stat, StatHelpText, StatLabel } from '@chakra-ui/react'
+import { FaQrcode, FaStamp } from 'react-icons/fa'
+import { TokenDTO } from 'types/dto/token'
+import { Paragraph } from 'components/@commons/Basics'
+
+export const QRList: React.FC = (props) => {
+  //Mock data for tokens
+  const token_response: TokenDTO[] = [
+    { title: 'Mock Token 1', type: 'KÖR' },
+    { title: 'Kir-Dev token of awesomeness', type: 'KÖR' },
+    { title: 'Úristen ez a title very big. Very Very Big', type: 'KÖR' }
+  ]
+
+  return (
+    <Page {...props}>
+      <Heading>QR kód vadászat</Heading>
+      <Paragraph>
+        A standoknál végzett aktív tevékenyégért QR kódokat lehet gyűjteni, amiket tanköri hiányzások igazolására lehet beváltani. TODO:
+        Fogalmazzunk meg ide szöveget, mert ma bevettem a fogalmazás gátlóm.
+      </Paragraph>
+
+      <Button colorScheme={'brand'} leftIcon={<FaQrcode />}>
+        QR kód beolvasása
+      </Button>
+
+      <Heading>Haladás</Heading>
+      <Heading as="h4" size="md">
+        Eddig beolvasott tokenek: {token_response.length} / 5
+      </Heading>
+
+      <Progress hasStripe colorScheme="brand" value={(100 * token_response.length) / 5} />
+      <Heading as="h4" size="md">
+        Amhol eddig jártál
+      </Heading>
+      <Stack spacing="5" alignItems={'center'}>
+        {token_response.map((token, i) => {
+          return (
+            <Box key={i} maxW={'md'} minW={'md'} borderWidth="1px" borderRadius={'lg'} overflow={'hidden'} boxShadow="lg" bg="brand.100">
+              <Flex>
+                <Center bg={'brand.300'} padding="2">
+                  <Icon as={FaStamp} boxSize="2em" fontSize="3xl" />
+                </Center>
+                <Center width="100%" paddingStart={'3'} textAlign="center">
+                  <Stat>
+                    <StatLabel fontSize="xl">{token.title}</StatLabel>
+                    <StatHelpText>{token.type}</StatHelpText>
+                  </Stat>
+                </Center>
+              </Flex>
+            </Box>
+          )
+        })}
+      </Stack>
+    </Page>
+  )
+}

--- a/src/main/client/src/components/@pages/QRList.tsx
+++ b/src/main/client/src/components/@pages/QRList.tsx
@@ -11,11 +11,7 @@ import { API_BASE_URL } from 'utils/configurations'
 import { ProfileDTO } from 'types/dto/profile'
 
 export const QRList: React.FC = (props) => {
-  const [tokens, setTokens] = useState<TokenDTO[]>([
-    { title: 'Mock Token 1', type: 'KÖR' },
-    { title: 'Kir-Dev token of awesomeness', type: 'KÖR' },
-    { title: 'Úristen ez a title very big. Very Very Big', type: 'KÖR' }
-  ])
+  const [tokens, setTokens] = useState<TokenDTO[]>([])
   const [totalTokenCount, setTotalTokenCount] = useState<number>(0)
   const navigate = useNavigate()
 

--- a/src/main/client/src/components/@pages/QRList.tsx
+++ b/src/main/client/src/components/@pages/QRList.tsx
@@ -4,6 +4,7 @@ import { Heading, Button, Progress, Stack, Icon, Center, Flex, Box, Stat, StatHe
 import { FaQrcode, FaStamp } from 'react-icons/fa'
 import { TokenDTO } from 'types/dto/token'
 import { Paragraph } from 'components/@commons/Basics'
+import { useNavigate } from 'react-router-dom'
 
 export const QRList: React.FC = (props) => {
   //Mock data for tokens
@@ -13,6 +14,12 @@ export const QRList: React.FC = (props) => {
     { title: 'Úristen ez a title very big. Very Very Big', type: 'KÖR' }
   ]
 
+  const navigate = useNavigate()
+
+  const scanEventHandler = () => {
+    navigate('/qr/scan')
+  }
+
   return (
     <Page {...props}>
       <Heading>QR kód vadászat</Heading>
@@ -21,7 +28,7 @@ export const QRList: React.FC = (props) => {
         Fogalmazzunk meg ide szöveget, mert ma bevettem a fogalmazás gátlóm.
       </Paragraph>
 
-      <Button colorScheme={'brand'} leftIcon={<FaQrcode />}>
+      <Button colorScheme={'brand'} leftIcon={<FaQrcode />} onClick={scanEventHandler}>
         QR kód beolvasása
       </Button>
 
@@ -37,7 +44,7 @@ export const QRList: React.FC = (props) => {
       <Stack spacing="5" alignItems={'center'}>
         {token_response.map((token, i) => {
           return (
-            <Box key={i} maxW={'md'} minW={'md'} borderWidth="1px" borderRadius={'lg'} overflow={'hidden'} boxShadow="lg" bg="brand.100">
+            <Box key={i} maxW={'md'} minW={'md'} borderWidth="1px" borderRadius={'lg'} boxShadow="lg" bg="brand.100">
               <Flex>
                 <Center bg={'brand.300'} padding="2">
                   <Icon as={FaStamp} boxSize="2em" fontSize="3xl" />

--- a/src/main/client/src/components/@pages/QRList.tsx
+++ b/src/main/client/src/components/@pages/QRList.tsx
@@ -1,6 +1,6 @@
 import { Page } from '../@layout/Page'
 import React from 'react'
-import { Heading, Button, Progress, Stack } from '@chakra-ui/react'
+import { Heading, Button, Progress, Stack, ButtonGroup } from '@chakra-ui/react'
 import { FaQrcode } from 'react-icons/fa'
 import { TokenDTO } from 'types/dto/token'
 import { Paragraph } from 'components/@commons/Basics'
@@ -29,9 +29,11 @@ export const QRList: React.FC = (props) => {
         Fogalmazzunk meg ide szöveget, mert ma bevettem a fogalmazás gátlóm.
       </Paragraph>
 
-      <Button colorScheme={'brand'} leftIcon={<FaQrcode />} onClick={scanEventHandler}>
-        QR kód beolvasása
-      </Button>
+      <ButtonGroup>
+        <Button colorScheme={'brand'} leftIcon={<FaQrcode />} onClick={scanEventHandler}>
+          QR kód beolvasása
+        </Button>
+      </ButtonGroup>
 
       <Heading>Haladás</Heading>
       <Heading as="h4" size="md">
@@ -42,7 +44,7 @@ export const QRList: React.FC = (props) => {
       <Heading as="h4" size="md">
         Ahol eddig jártál
       </Heading>
-      <Stack spacing="5" alignItems={'center'}>
+      <Stack spacing="5" alignItems={{ base: 'center', md: 'start' }}>
         {token_response.map((token, i) => {
           return <StampComponent key={i} title={token.title} type={token.type}></StampComponent>
         })}

--- a/src/main/client/src/components/@pages/QRList.tsx
+++ b/src/main/client/src/components/@pages/QRList.tsx
@@ -1,24 +1,44 @@
 import { Page } from '../@layout/Page'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Heading, Button, Progress, Stack, ButtonGroup } from '@chakra-ui/react'
 import { FaQrcode } from 'react-icons/fa'
 import { TokenDTO } from 'types/dto/token'
 import { Paragraph } from 'components/@commons/Basics'
 import { useNavigate } from 'react-router-dom'
 import { StampComponent } from 'components/@commons/StampComponent'
+import axios from 'axios'
+import { API_BASE_URL } from 'utils/configurations'
+import { ProfileDTO } from 'types/dto/profile'
 
 export const QRList: React.FC = (props) => {
-  //Mock data for tokens
-  const token_response: TokenDTO[] = [
+  const [tokens, setTokens] = useState<TokenDTO[]>([
     { title: 'Mock Token 1', type: 'KÖR' },
     { title: 'Kir-Dev token of awesomeness', type: 'KÖR' },
     { title: 'Úristen ez a title very big. Very Very Big', type: 'KÖR' }
-  ]
-
+  ])
+  const [totalTokenCount, setTotalTokenCount] = useState<number>(0)
   const navigate = useNavigate()
+
+  useEffect(() => {
+    axios
+      .get(`${API_BASE_URL}/api/profile`)
+      .then((res) => {
+        const profile = res.data as ProfileDTO
+        setTokens(profile.tokens || [])
+        setTotalTokenCount(profile.totalTokenCount || 0)
+      })
+      .catch((err) => {
+        console.log(err)
+      })
+  }, [])
 
   const scanEventHandler = () => {
     navigate('/qr/scan')
+  }
+
+  const calculate_progress = () => {
+    if (totalTokenCount == 0) return 100
+    else return (100 * tokens.length) / totalTokenCount
   }
 
   return (
@@ -37,15 +57,15 @@ export const QRList: React.FC = (props) => {
 
       <Heading>Haladás</Heading>
       <Heading as="h4" size="md">
-        Eddig beolvasott tokenek: {token_response.length} / 5
+        Eddig beolvasott tokenek: {tokens.length} / {totalTokenCount}
       </Heading>
 
-      <Progress hasStripe colorScheme="brand" value={(100 * token_response.length) / 5} />
+      <Progress hasStripe colorScheme="brand" value={calculate_progress()} />
       <Heading as="h4" size="md">
         Ahol eddig jártál
       </Heading>
       <Stack spacing="5" alignItems={{ base: 'center', md: 'start' }}>
-        {token_response.map((token, i) => {
+        {tokens.map((token, i) => {
           return <StampComponent key={i} title={token.title} type={token.type}></StampComponent>
         })}
       </Stack>

--- a/src/main/client/src/components/@pages/QRScan.tsx
+++ b/src/main/client/src/components/@pages/QRScan.tsx
@@ -1,0 +1,10 @@
+import { Heading } from '@chakra-ui/react'
+import { Page } from 'components/@layout/Page'
+
+export const QRScan: React.FC = (props) => {
+  return (
+    <Page {...props}>
+      <Heading>QR kód scannelése</Heading>
+    </Page>
+  )
+}

--- a/src/main/client/src/components/@pages/QRScan.tsx
+++ b/src/main/client/src/components/@pages/QRScan.tsx
@@ -12,14 +12,27 @@ import {
   Heading
 } from '@chakra-ui/react'
 import axios from 'axios'
-import { QrScanResultComponent } from 'components/@commons/QrScanResultComponent'
+import { QRScanResultComponent } from 'components/@commons/QRScanResultComponent'
 import { Page } from 'components/@layout/Page'
 import React from 'react'
 import { FaArrowLeft, FaQrcode } from 'react-icons/fa'
 import QRreader from 'react-qr-reader'
 import { useNavigate } from 'react-router-dom'
-import { ScanStatus, ScanView, ScanViewState } from 'types/dto/token'
+import { ScanResponseDTO, ScanStatus } from 'types/dto/token'
 import { API_BASE_URL } from 'utils/configurations'
+
+enum ScanViewState {
+  Scanning,
+  Loading,
+  Error,
+  Success
+}
+
+interface ScanView {
+  state: ScanViewState
+  response?: ScanResponseDTO
+  errorMessage?: string
+}
 
 export const QRScan: React.FC = (props) => {
   const [state, setState] = React.useState<ScanView>({ state: ScanViewState.Scanning })
@@ -42,12 +55,14 @@ export const QRScan: React.FC = (props) => {
         .then((res) => {
           setState({ state: ScanViewState.Success, response: res.data })
         })
+        //catch any network error
         .catch((err) => {
           console.log(err)
           setState({ state: ScanViewState.Error, errorMessage: 'A szerver nem válaszol!' })
         })
     }
   }
+  //handle any scanner error
   const handleError = (err: any) => {
     console.log(err)
   }
@@ -78,7 +93,7 @@ export const QRScan: React.FC = (props) => {
       )}
       {state.state == ScanViewState.Success && (
         <Fade in={state.state == ScanViewState.Success}>
-          <QrScanResultComponent response={state.response || { status: ScanStatus.WRONG }}></QrScanResultComponent>
+          <QRScanResultComponent response={state.response || { status: ScanStatus.WRONG }}></QRScanResultComponent>
         </Fade>
       )}
       {state.state !== ScanViewState.Loading && (

--- a/src/main/client/src/components/@pages/QRScan.tsx
+++ b/src/main/client/src/components/@pages/QRScan.tsx
@@ -1,10 +1,52 @@
-import { Heading } from '@chakra-ui/react'
+import { CheckCircleIcon } from '@chakra-ui/icons'
+import { Alert, AlertDescription, AlertIcon, AlertTitle, Center, CircularProgress, CloseButton, Fade, Heading } from '@chakra-ui/react'
 import { Page } from 'components/@layout/Page'
+import React from 'react'
+import QRreader from 'react-qr-reader'
+import { ScanView, ScanViewState } from 'types/dto/token'
 
 export const QRScan: React.FC = (props) => {
+  const [state, setState] = React.useState<ScanView>({ state: ScanViewState.Scanning })
+
+  const handleScan = (data: any) => {
+    if (data) {
+      console.log(data)
+      setState({ state: ScanViewState.Loading })
+      setTimeout(() => {
+        setState({ state: ScanViewState.Success })
+      }, 1500)
+    }
+  }
+  const handleError = (err: any) => {
+    console.log(err)
+  }
+
   return (
     <Page {...props}>
-      <Heading>QR kód scannelése</Heading>
+      <Heading>Scanneld be a QR kódot</Heading>
+      {state.state == ScanViewState.Scanning && <QRreader delay={300} onError={handleError} onScan={handleScan}></QRreader>}
+      {state.state == ScanViewState.Error && (
+        <Alert status="error">
+          <AlertIcon />
+          <AlertTitle mr={2}>Valami hibát dobott</AlertTitle>
+          <AlertDescription>{state.errorMessage ? state.errorMessage : 'Próbáld újra'}</AlertDescription>
+          <CloseButton position="absolute" right="8px" top="8px" />
+        </Alert>
+      )}
+      {state.state == ScanViewState.Loading && (
+        <Center>
+          <CircularProgress isIndeterminate color="brand.300" size="120px" />
+        </Center>
+      )}
+
+      <Fade in={state.state == ScanViewState.Success}>
+        <Center p="40px" mt="4">
+          <CheckCircleIcon color="brand.500" boxSize="120px" />
+        </Center>
+        <Center>
+          <Heading>Állomás lepecsételve</Heading>
+        </Center>
+      </Fade>
     </Page>
   )
 }

--- a/src/main/client/src/components/@pages/QRScan.tsx
+++ b/src/main/client/src/components/@pages/QRScan.tsx
@@ -1,12 +1,26 @@
 import { CheckCircleIcon } from '@chakra-ui/icons'
-import { Alert, AlertDescription, AlertIcon, AlertTitle, Center, CircularProgress, CloseButton, Fade, Heading } from '@chakra-ui/react'
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  AlertTitle,
+  Button,
+  ButtonGroup,
+  Center,
+  CircularProgress,
+  CloseButton,
+  Fade,
+  Heading
+} from '@chakra-ui/react'
 import { Page } from 'components/@layout/Page'
 import React from 'react'
 import QRreader from 'react-qr-reader'
+import { useNavigate } from 'react-router-dom'
 import { ScanView, ScanViewState } from 'types/dto/token'
 
 export const QRScan: React.FC = (props) => {
   const [state, setState] = React.useState<ScanView>({ state: ScanViewState.Scanning })
+  const navigate = useNavigate()
 
   const handleScan = (data: any) => {
     if (data) {
@@ -19,6 +33,10 @@ export const QRScan: React.FC = (props) => {
   }
   const handleError = (err: any) => {
     console.log(err)
+  }
+
+  const backButtonHandler = () => {
+    navigate('/qr')
   }
 
   return (
@@ -38,6 +56,11 @@ export const QRScan: React.FC = (props) => {
           <CircularProgress isIndeterminate color="brand.300" size="120px" />
         </Center>
       )}
+      <ButtonGroup>
+        <Button marginTop="3" colorScheme="brand" onClick={backButtonHandler} size="lg">
+          Vissza
+        </Button>
+      </ButtonGroup>
 
       <Fade in={state.state == ScanViewState.Success}>
         <Center p="40px" mt="4">

--- a/src/main/client/src/components/@pages/QRScan.tsx
+++ b/src/main/client/src/components/@pages/QRScan.tsx
@@ -97,7 +97,7 @@ export const QRScan: React.FC = (props) => {
         </Fade>
       )}
       {state.state !== ScanViewState.Loading && (
-        <ButtonGroup>
+        <ButtonGroup alignSelf="center">
           <Button marginTop="3" leftIcon={<FaArrowLeft />} onClick={backButtonHandler} size="lg">
             Vissza
           </Button>

--- a/src/main/client/src/components/@pages/QRScanResult.tsx
+++ b/src/main/client/src/components/@pages/QRScanResult.tsx
@@ -2,7 +2,9 @@ import { Page } from '../@layout/Page'
 import React from 'react'
 import { ScanResponseDTO, ScanStatus } from 'types/dto/token'
 import { QrScanResultComponent } from 'components/@commons/QrScanResultComponent'
-import { useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { ButtonGroup, Button } from '@chakra-ui/react'
+import { FaArrowLeft, FaQrcode } from 'react-icons/fa'
 
 export const QRScanResult: React.FC = (props) => {
   const [searchParams] = useSearchParams()
@@ -10,9 +12,26 @@ export const QRScanResult: React.FC = (props) => {
     title: searchParams.get('title') || undefined,
     status: (searchParams.get('status') || ScanStatus.WRONG) as ScanStatus
   }
+  const navigate = useNavigate()
+
+  const scanEventHandler = () => {
+    navigate('/qr/scan')
+  }
+  const backButtonHandler = () => {
+    navigate('/qr')
+  }
+
   return (
     <Page {...props}>
       <QrScanResultComponent response={server_response} />
+      <ButtonGroup spacing="6">
+        <Button leftIcon={<FaArrowLeft />} onClick={backButtonHandler}>
+          Vissza{' '}
+        </Button>
+        <Button colorScheme="brand" leftIcon={<FaQrcode />} onClick={scanEventHandler}>
+          Új QR-kód scannelése
+        </Button>
+      </ButtonGroup>
     </Page>
   )
 }

--- a/src/main/client/src/components/@pages/QRScanResult.tsx
+++ b/src/main/client/src/components/@pages/QRScanResult.tsx
@@ -1,7 +1,7 @@
 import { Page } from '../@layout/Page'
 import React from 'react'
 import { ScanResponseDTO, ScanStatus } from 'types/dto/token'
-import { QrScanResultComponent } from 'components/@commons/QrScanResultComponent'
+import { QRScanResultComponent } from 'components/@commons/QRScanResultComponent'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { ButtonGroup, Button } from '@chakra-ui/react'
 import { FaArrowLeft, FaQrcode } from 'react-icons/fa'
@@ -23,7 +23,7 @@ export const QRScanResult: React.FC = (props) => {
 
   return (
     <Page {...props}>
-      <QrScanResultComponent response={server_response} />
+      <QRScanResultComponent response={server_response} />
       <ButtonGroup spacing="6">
         <Button leftIcon={<FaArrowLeft />} onClick={backButtonHandler}>
           Vissza{' '}

--- a/src/main/client/src/components/@pages/QRScanResult.tsx
+++ b/src/main/client/src/components/@pages/QRScanResult.tsx
@@ -24,7 +24,7 @@ export const QRScanResult: React.FC = (props) => {
   return (
     <Page {...props}>
       <QRScanResultComponent response={server_response} />
-      <ButtonGroup spacing="6">
+      <ButtonGroup spacing="6" alignSelf="center">
         <Button leftIcon={<FaArrowLeft />} onClick={backButtonHandler}>
           Vissza{' '}
         </Button>

--- a/src/main/client/src/components/@pages/QRScanResult.tsx
+++ b/src/main/client/src/components/@pages/QRScanResult.tsx
@@ -1,0 +1,18 @@
+import { Page } from '../@layout/Page'
+import React from 'react'
+import { ScanResponseDTO, ScanStatus } from 'types/dto/token'
+import { QrScanResultComponent } from 'components/@commons/QrScanResultComponent'
+import { useSearchParams } from 'react-router-dom'
+
+export const QRScanResult: React.FC = (props) => {
+  const [searchParams] = useSearchParams()
+  const server_response: ScanResponseDTO = {
+    title: searchParams.get('title') || undefined,
+    status: (searchParams.get('status') || ScanStatus.WRONG) as ScanStatus
+  }
+  return (
+    <Page {...props}>
+      <QrScanResultComponent response={server_response} />
+    </Page>
+  )
+}

--- a/src/main/client/src/types/dto/profile.ts
+++ b/src/main/client/src/types/dto/profile.ts
@@ -1,0 +1,21 @@
+import { TokenDTO } from './token'
+
+export enum RoleType {
+  GUEST = 'GUEST', // anyone without login
+  BASIC = 'BASIC', // has auth.sch but not member of SSSL
+  STAFF = 'STAFF', // member of the SSSL
+  ADMIN = 'ADMIN', // the organizers of the event
+  SUPERUSER = 'SUPERUSER' // advanced user management (able to grant admin access)
+}
+
+export interface ProfileDTO {
+  completedRiddleCount: number
+  fullName: string
+  groupName: string
+  role: RoleType
+  submittedAchievementCount: number
+  tokens: TokenDTO[]
+  totalAchievementCount: number
+  totalRiddleCount: number
+  totalTokenCount: number
+}

--- a/src/main/client/src/types/dto/token.ts
+++ b/src/main/client/src/types/dto/token.ts
@@ -1,0 +1,4 @@
+export interface TokenDTO {
+  title: string
+  type: string
+}

--- a/src/main/client/src/types/dto/token.ts
+++ b/src/main/client/src/types/dto/token.ts
@@ -6,7 +6,8 @@ export interface TokenDTO {
 export enum ScanStatus {
   SCANNED = 'SCANNED',
   ALREADY_SCANNED = 'ALREADY_SCANNED',
-  WRONG = 'WRONG'
+  WRONG = 'WRONG',
+  CANNOT_COLLECT = 'CANNOT_COLLECT'
 }
 
 export interface ScanResponseDTO {

--- a/src/main/client/src/types/dto/token.ts
+++ b/src/main/client/src/types/dto/token.ts
@@ -4,9 +4,9 @@ export interface TokenDTO {
 }
 
 export enum ScanStatus {
-  SCANNED,
-  ALREADY_SCANNED,
-  WRONG
+  SCANNED = 'SCANNED',
+  ALREADY_SCANNED = 'ALREADY_SCANNED',
+  WRONG = 'WRONG'
 }
 
 export interface ScanResponseDTO {

--- a/src/main/client/src/types/dto/token.ts
+++ b/src/main/client/src/types/dto/token.ts
@@ -2,3 +2,27 @@ export interface TokenDTO {
   title: string
   type: string
 }
+
+export enum ScanStatus {
+  SCANNED,
+  ALREADY_SCANNED,
+  WRONG
+}
+
+export interface ScanResponseDTO {
+  title?: string
+  status: ScanStatus
+}
+
+export enum ScanViewState {
+  Scanning,
+  Loading,
+  Error,
+  Success
+}
+
+export interface ScanView {
+  state: ScanViewState
+  response?: ScanResponseDTO
+  errorMessage?: string
+}

--- a/src/main/client/src/types/dto/token.ts
+++ b/src/main/client/src/types/dto/token.ts
@@ -14,16 +14,3 @@ export interface ScanResponseDTO {
   title?: string
   status: ScanStatus
 }
-
-export enum ScanViewState {
-  Scanning,
-  Loading,
-  Error,
-  Success
-}
-
-export interface ScanView {
-  state: ScanViewState
-  response?: ScanResponseDTO
-  errorMessage?: string
-}

--- a/src/main/client/src/utils/navItems.ts
+++ b/src/main/client/src/utils/navItems.ts
@@ -14,6 +14,10 @@ export const NAV_ITEMS: Array<NavItem> = [
     href: '/korok'
   },
   {
+    label: 'QR',
+    href: '/qr'
+  },
+  {
     label: 'Profil',
     href: '/profil'
   }

--- a/src/main/client/yarn.lock
+++ b/src/main/client/yarn.lock
@@ -2431,6 +2431,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-qr-reader@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@types/react-qr-reader/-/react-qr-reader-2.1.4.tgz#a36f0b83b4402e26c4217d0e8af6b5e2887fc749"
+  integrity sha512-2Hq+UNfsO2TVqxbFlOE0gGhQr/+C4wdgNDaaLV8K93mK/Z7Vw2D3YbMlnJAaSzM45fUtYJs0vc48wV04+OEkiA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^17.0.15":
   version "17.0.38"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
@@ -6260,6 +6267,11 @@ jsonpointer@^5.0.0:
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.0.tgz#f802669a524ec4805fa7389eadbc9921d5dc8072"
   integrity sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==
 
+jsqr@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jsqr/-/jsqr-1.4.0.tgz#8efb8d0a7cc6863cb6d95116b9069123ce9eb2d1"
+  integrity sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==
+
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz#720b97bfe7d901b927d87c3773637ae8ea48781b"
@@ -7862,6 +7874,15 @@ react-merge-refs@^1.1.0:
   resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
   integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
 
+react-qr-reader@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-qr-reader/-/react-qr-reader-2.2.1.tgz#dc89046d1c1a1da837a683dd970de5926817d55b"
+  integrity sha512-EL5JEj53u2yAOgtpAKAVBzD/SiKWn0Bl7AZy6ZrSf1lub7xHwtaXe6XSx36Wbhl1VMGmvmrwYMRwO1aSCT2fwA==
+  dependencies:
+    jsqr "^1.2.0"
+    prop-types "^15.7.2"
+    webrtc-adapter "^7.2.1"
+
 react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
@@ -8206,6 +8227,13 @@ rollup@^2.43.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
+rtcpeerconnection-shim@^1.2.15:
+  version "1.2.15"
+  resolved "https://registry.yarnpkg.com/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.15.tgz#e7cc189a81b435324c4949aa3dfb51888684b243"
+  integrity sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==
+  dependencies:
+    sdp "^2.6.0"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -8297,6 +8325,11 @@ schema-utils@^4.0.0:
     ajv "^8.8.0"
     ajv-formats "^2.1.1"
     ajv-keywords "^5.0.0"
+
+sdp@^2.12.0, sdp@^2.6.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/sdp/-/sdp-2.12.0.tgz#338a106af7560c86e4523f858349680350d53b22"
+  integrity sha512-jhXqQAQVM+8Xj5EjJGVweuEzgtGWb3tmEEpl3CLP3cStInSbVHSg0QWOGQzNq8pSID4JkpeV2mPqlMDLrm0/Vw==
 
 select-hose@^2.0.0:
   version "2.0.0"
@@ -9391,6 +9424,14 @@ webpack@^5.64.4:
     terser-webpack-plugin "^5.1.3"
     watchpack "^2.3.1"
     webpack-sources "^3.2.2"
+
+webrtc-adapter@^7.2.1:
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/webrtc-adapter/-/webrtc-adapter-7.7.1.tgz#b2c227a6144983b35057df67bd984a7d4bfd17f1"
+  integrity sha512-TbrbBmiQBL9n0/5bvDdORc6ZfRY/Z7JnEj+EYOD1ghseZdpJ+nF2yx14k3LgQKc7JZnG7HAcL+zHnY25So9d7A==
+  dependencies:
+    rtcpeerconnection-shim "^1.2.15"
+    sdp "^2.12.0"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
   version "0.7.4"


### PR DESCRIPTION
Done the views for token collection:
 - Show progress, and list already scanned codes
 - Scan new qr code
 - Redirect page for manual 
 
Wired in axios requests in the list view and scan view, but i think we should outsource the api communication in  a service file and handle network errors in one place, that way the pages would look nicer, and the error handling would be the same across the site.

I didn't use the [recommended](https://github.com/nimiq/qr-scanner) QR lib, because i would have to manually wire in a service worker js file, but the `react-qr-reader` package does it for me. 
The QR reader right now won't work because there is a bug on backend side with the post API.

!! 
> Due to browser implementations the camera can only be accessed over https or localhost.

closes #33 
closes #12 