### PR TITLE
Breadcrumb, achievement submission date and darkmode buttons fix

### DIFF
--- a/src/main/client/src/components/@commons/CustomBreadcrumb.tsx
+++ b/src/main/client/src/components/@commons/CustomBreadcrumb.tsx
@@ -6,7 +6,6 @@ type BreadcrumbProps = {
   items: {
     title?: string
     to?: string
-    color?: string
   }[]
 }
 
@@ -22,7 +21,7 @@ export const CustomBreadcrumb: React.FC<BreadcrumbProps> = ({ items }) => {
             fontWeight={500}
             _hover={{
               textDecoration: 'none',
-              color: item.color || 'brand.500'
+              color: 'brand.500'
             }}
           >
             {item.title}

--- a/src/main/client/src/components/@pages/AchievementCategoryList.tsx
+++ b/src/main/client/src/components/@pages/AchievementCategoryList.tsx
@@ -79,7 +79,7 @@ export const AchievementCategoryList: React.FC = (props) => {
           ))}
         </VStack>
       ) : (
-        <Text>Nincs egyetlen bucketlist challenge se.</Text>
+        <Text>Nincs egyetlen bucketlist feladat se.</Text>
       )}
     </Page>
   )

--- a/src/main/client/src/components/@pages/AchievementCategoryPage.tsx
+++ b/src/main/client/src/components/@pages/AchievementCategoryPage.tsx
@@ -76,7 +76,7 @@ export const AchievementCategoryPage: React.FC = (props) => {
           ))}
         </VStack>
       ) : (
-        <Text>Nincs egyetlen bucketlist challenge se ebben a kategóriában.</Text>
+        <Text>Nincs egyetlen bucketlist feladat se ebben a kategóriában.</Text>
       )}
     </Page>
   )

--- a/src/main/client/src/components/@pages/AchievementPage.tsx
+++ b/src/main/client/src/components/@pages/AchievementPage.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, FormLabel, Heading, Stack, Text, Textarea, Image, useToast, Skeleton } from '@chakra-ui/react'
+import { Box, Button, FormLabel, Heading, Stack, Text, Textarea, Image, useToast, Skeleton, Alert, AlertIcon } from '@chakra-ui/react'
 import { chakra } from '@chakra-ui/system'
 import { Page } from '../@layout/Page'
 import React, { useEffect, useState, useRef } from 'react'
@@ -14,6 +14,7 @@ import { Loading } from '../../utils/Loading'
 import { useServiceContext } from '../../utils/useServiceContext'
 import { Helmet } from 'react-helmet'
 import { CustomBreadcrumb } from 'components/@commons/CustomBreadcrumb'
+import { stringifyTimeStamp } from '../../utils/utilFunctions'
 
 export const AchievementPage: React.FC = (props) => {
   const [achDetails, setAchDetails] = useState<AchievementFullDetailsView | undefined>(undefined)
@@ -222,7 +223,10 @@ export const AchievementPage: React.FC = (props) => {
           <Heading size="md" mt={8}>
             {achDetails.status === achievementStatus.REJECTED ? 'Újra beküldés' : 'Beküldés'}
           </Heading>
-          <Stack mt={2}>
+          <Stack mt={5}>
+            <Alert variant="left-accent" status="info">
+              <AlertIcon />A feladat beadási határideje: {stringifyTimeStamp(achDetails.achievement?.availableTo || 0)}
+            </Alert>
             {textInput}
             {fileInput}
             <Box>

--- a/src/main/client/src/components/@pages/CommunityPage.tsx
+++ b/src/main/client/src/components/@pages/CommunityPage.tsx
@@ -27,8 +27,7 @@ export const CommunityPage: React.FC<CommunityPageProps> = () => {
       color: resort?.color
     },
     {
-      title: community.name,
-      color: community.color
+      title: community.name
     }
   ]
   return (

--- a/src/main/client/src/components/@pages/ResortPage.tsx
+++ b/src/main/client/src/components/@pages/ResortPage.tsx
@@ -20,8 +20,7 @@ export const ResortPage: React.FC<ResortPageProps> = () => {
       to: '/reszortok'
     },
     {
-      title: resort.name,
-      color: resort.color
+      title: resort.name
     }
   ]
   return (

--- a/src/main/client/src/types/dto/achievements.ts
+++ b/src/main/client/src/types/dto/achievements.ts
@@ -44,8 +44,8 @@ export interface AchievementEntity {
   description: string
   type: achievementType
   expectedResultDescription?: string
-  availableFrom?: number
-  availableTo?: number
+  availableFrom: number
+  availableTo: number
 }
 
 export interface AchievementWrapper {

--- a/src/main/client/src/utils/customTheme.ts
+++ b/src/main/client/src/utils/customTheme.ts
@@ -1,5 +1,5 @@
 import { extendTheme } from '@chakra-ui/react'
-import { mode } from '@chakra-ui/theme-tools'
+import { mode, SystemStyleObject } from '@chakra-ui/theme-tools'
 
 // See more: https://chakra-ui.com/docs/theming/customize-theme
 const customTheme = extendTheme({
@@ -34,6 +34,44 @@ const customTheme = extendTheme({
     Text: {
       baseStyle: {
         fontSize: 'lg'
+      }
+    },
+    Button: {
+      variants: {
+        solid: (props: SystemStyleObject) => {
+          const { colorScheme: c } = props
+          if (c === 'gray') {
+            const bg = mode(`gray.100`, `whiteAlpha.200`)(props)
+            return {
+              bg,
+              _hover: {
+                bg: mode(`gray.200`, `whiteAlpha.300`)(props),
+                _disabled: {
+                  bg
+                }
+              },
+              _active: { bg: mode(`gray.300`, `whiteAlpha.400`)(props) }
+            }
+          }
+          const yellowOrCyan = c === 'yellow' || c === 'cyan'
+          const bg = yellowOrCyan ? `${c}.400` : `${c}.500`
+          const color = yellowOrCyan ? 'black' : 'white'
+          const hoverBg = yellowOrCyan ? `${c}.500` : `${c}.600`
+          const activeBg = yellowOrCyan ? `${c}.600` : `${c}.700`
+
+          const background = mode(bg, `${c}.700`)(props)
+          return {
+            bg: background,
+            color: mode(color, `whiteAlpha.900`)(props),
+            _hover: {
+              bg: mode(hoverBg, `${c}.600`)(props),
+              _disabled: {
+                bg: background
+              }
+            },
+            _active: { bg: mode(activeBg, `${c}.600`)(props) }
+          }
+        }
       }
     }
   }

--- a/src/main/client/src/utils/utilFunctions.ts
+++ b/src/main/client/src/utils/utilFunctions.ts
@@ -1,0 +1,10 @@
+export const TIMESTAMP_OPTIONS: Intl.DateTimeFormatOptions = {
+  month: 'short',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit'
+}
+
+export const stringifyTimeStamp = (timeStamp: number, options: Intl.DateTimeFormatOptions = TIMESTAMP_OPTIONS): string => {
+  return new Date(timeStamp * 1000).toLocaleString('hu-HU', options)
+}


### PR DESCRIPTION
- removed the different colors from the Breadcrumbs on the resort and community pages, it always uses the brand color
- Added an infobox to the achievement submission form that shows the submission deadline
- It uses the date formatter function from #109 
- redefined the colors of solid buttons in darkmode globally. In `customTheme.ts` I overrode the function that generates the color values for solid buttons (I copied the function from the chakra source code and changed some values to make the buttons darker in darkMode)
Before and after: (there was no change in lightmode or to the outline variants)
![image](https://user-images.githubusercontent.com/13004605/151670995-2e794d76-5bb8-4715-bdae-db2f754e22e1.png) 
![image](https://user-images.githubusercontent.com/13004605/151671057-212c8171-dba0-4621-8f93-77679fe2aa98.png)

![image](https://user-images.githubusercontent.com/13004605/151671021-4f1d75fe-ec1d-4fe3-971e-035ec506b1dc.png)
![image](https://user-images.githubusercontent.com/13004605/151671072-4be16c86-2435-43b2-935e-56345522b0e6.png)

