### PR TITLE
Consistent green colors

### DIFF
--- a/src/main/client/src/components/@commons/CustomBreadcrumb.tsx
+++ b/src/main/client/src/components/@commons/CustomBreadcrumb.tsx
@@ -1,5 +1,5 @@
 import { ChevronRightIcon } from '@chakra-ui/icons'
-import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, SpaceProps } from '@chakra-ui/react'
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, SpaceProps, useColorModeValue } from '@chakra-ui/react'
 import { Link } from 'react-router-dom'
 
 type BreadcrumbProps = {
@@ -11,7 +11,7 @@ type BreadcrumbProps = {
 
 export const CustomBreadcrumb: React.FC<BreadcrumbProps> = ({ items, ...spaceProps }) => {
   return (
-    <Breadcrumb {...spaceProps} spacing={2} separator={<ChevronRightIcon color={'brand.500'} />}>
+    <Breadcrumb {...spaceProps} spacing={2} separator={<ChevronRightIcon color={useColorModeValue('brand.500', 'brand.600')} />}>
       {items.map((item, idx) => (
         <BreadcrumbItem key={idx}>
           <BreadcrumbLink
@@ -21,7 +21,7 @@ export const CustomBreadcrumb: React.FC<BreadcrumbProps> = ({ items, ...spacePro
             fontWeight={500}
             _hover={{
               textDecoration: 'none',
-              color: 'brand.500'
+              color: useColorModeValue('brand.500', 'brand.600')
             }}
           >
             {item.title}

--- a/src/main/client/src/components/@commons/QRScanResultComponent.tsx
+++ b/src/main/client/src/components/@commons/QRScanResultComponent.tsx
@@ -45,7 +45,9 @@ export const QRScanResultComponent: React.FC<QrScanResultProps> = ({ response }:
         {renderIcon()}
       </Center>
       <Center>
-        <Heading size="md">{getInfoText()}</Heading>
+        <Heading mb={5} size="md">
+          {getInfoText()}
+        </Heading>
       </Center>
     </Box>
   )

--- a/src/main/client/src/components/@commons/QRScanResultComponent.tsx
+++ b/src/main/client/src/components/@commons/QRScanResultComponent.tsx
@@ -1,5 +1,5 @@
 import { CheckCircleIcon, InfoIcon, WarningIcon, WarningTwoIcon } from '@chakra-ui/icons'
-import { Box, Center, Heading } from '@chakra-ui/react'
+import { Box, Center, Heading, useColorModeValue } from '@chakra-ui/react'
 import React from 'react'
 import { ScanResponseDTO, ScanStatus } from 'types/dto/token'
 
@@ -11,7 +11,7 @@ export const QRScanResultComponent: React.FC<QrScanResultProps> = ({ response }:
   const renderIcon = () => {
     switch (response.status) {
       case ScanStatus.SCANNED:
-        return <CheckCircleIcon color="brand.500" boxSize="120px" />
+        return <CheckCircleIcon color={useColorModeValue('brand.500', 'brand.600')} boxSize="120px" />
       case ScanStatus.ALREADY_SCANNED:
         return <InfoIcon color="orange.500" boxSize="120px" />
       case ScanStatus.WRONG:

--- a/src/main/client/src/components/@commons/Schedule.tsx
+++ b/src/main/client/src/components/@commons/Schedule.tsx
@@ -24,7 +24,7 @@ const EventDisplay: React.FC<EventDisplayProps> = ({ event }) => {
   return (
     <>
       <GridItem textAlign="right">
-        <Text fontSize="2xl" color={useColorModeValue('brand.700', 'brand.300')}>
+        <Text fontSize="2xl" color={useColorModeValue('brand.500', 'brand.600')}>
           {event.start}-{event.end}
         </Text>
       </GridItem>

--- a/src/main/client/src/components/@commons/StampComponent.tsx
+++ b/src/main/client/src/components/@commons/StampComponent.tsx
@@ -19,7 +19,7 @@ export const StampComponent: React.FC<StampComponentProps> = ({ title, type }: S
     <Box maxW="md" minW={['100%', 'md']} borderRadius="lg" bg={backgroundBase}>
       <Flex>
         <Center bg={stampCorner} padding="2" borderStartRadius="lg">
-          <Icon as={icon} boxSize="2em" fontSize="3xl" color="brand.500" />
+          <Icon as={icon} boxSize="2em" fontSize="3xl" color={useColorModeValue('brand.500', 'brand.600')} />
         </Center>
         <Center width="100%" paddingStart="3" textAlign="center">
           <Text fontSize="xl" fontWeight="bold">

--- a/src/main/client/src/components/@layout/Footer.tsx
+++ b/src/main/client/src/components/@layout/Footer.tsx
@@ -31,7 +31,7 @@ const ImpressumWrapItem: React.FC<ImpressumWrapItemProps> = ({ display }) => {
         </Link>
       </Text>
       <Box align="center">
-        <Text>@ kir-dev [kukac] sch.bme.hu</Text>
+        <Text>@ kir-dev [at] sch.bme.hu</Text>
         <Text>© 2022</Text>
       </Box>
     </FooterWrapItem>

--- a/src/main/client/src/components/@layout/navigation/DesktopNav.tsx
+++ b/src/main/client/src/components/@layout/navigation/DesktopNav.tsx
@@ -11,10 +11,10 @@ import { useAuthContext } from '../../../utils/useAuthContext'
 const DesktopSubNav: React.FC<NavItem> = ({ label, href }) => {
   return (
     <Link to={href || '#'}>
-      <Box role="group" display="block" p={2} rounded="md" _hover={{ bg: useColorModeValue('brand.50', 'gray.800') }}>
+      <Box role="group" display="block" p={2} rounded="md">
         <Stack direction="row" align="center">
           <Box>
-            <Text transition="all .3s ease" _groupHover={{ color: 'brand.500' }} fontWeight={500}>
+            <Text transition="all .3s ease" _groupHover={{ color: useColorModeValue('brand.500', 'brand.600') }} fontWeight={500}>
               {label}
             </Text>
           </Box>
@@ -27,7 +27,7 @@ const DesktopSubNav: React.FC<NavItem> = ({ label, href }) => {
             align="center"
             flex={1}
           >
-            <Icon color="brand.500" w={5} h={5} as={ChevronRightIcon} />
+            <Icon color={useColorModeValue('brand.500', 'brand.600')} w={5} h={5} as={ChevronRightIcon} />
           </Flex>
         </Stack>
       </Box>
@@ -47,7 +47,7 @@ const DesktopNav: React.FC = () => {
                 <HStack
                   _hover={{
                     textDecoration: 'none',
-                    color: 'brand.500'
+                    color: useColorModeValue('brand.500', 'brand.600')
                   }}
                 >
                   <Text fontSize="md" fontWeight={500}>

--- a/src/main/client/src/components/@layout/navigation/Navbar.tsx
+++ b/src/main/client/src/components/@layout/navigation/Navbar.tsx
@@ -27,7 +27,6 @@ export const Navbar: React.FC<NavbarProps> = ({}) => {
             icon={isOpen ? <CloseIcon w={3} h={3} /> : <HamburgerIcon w={5} h={5} />}
             variant="ghost"
             aria-label="Navigáció megnyitása"
-            colorScheme="brand"
           />
         </Flex>
         <Flex flex={{ base: 1 }} justify={{ base: 'center', md: 'start' }}>

--- a/src/main/client/src/components/@pages/AchievementCategoryList.tsx
+++ b/src/main/client/src/components/@pages/AchievementCategoryList.tsx
@@ -75,7 +75,12 @@ export const AchievementCategoryList: React.FC = (props) => {
                   <Text fontWeight="bold" fontSize="xl">
                     {category.name}
                   </Text>
-                  <Box bgGradient={progressGradient(progress(category), 'brand.600')} px={1} py={1} borderRadius="6px">
+                  <Box
+                    bgGradient={progressGradient(progress(category), useColorModeValue('brand.500', 'brand.600'))}
+                    px={1}
+                    py={1}
+                    borderRadius="6px"
+                  >
                     <Text bg={bg} px={4} py={2} borderRadius="6px" fontWeight="bold">
                       {category.approved + category.notGraded} / {category.sum}
                     </Text>

--- a/src/main/client/src/components/@pages/Home.tsx
+++ b/src/main/client/src/components/@pages/Home.tsx
@@ -1,4 +1,4 @@
-import { Alert, AlertIcon, Box, ButtonGroup, Flex, Heading, Stack, VStack, Image } from '@chakra-ui/react'
+import { Alert, AlertIcon, Box, ButtonGroup, Flex, Heading, Stack, VStack, Image, useColorModeValue } from '@chakra-ui/react'
 import { Paragraph } from '../@commons/Basics'
 import { Page } from '../@layout/Page'
 import React from 'react'
@@ -16,7 +16,7 @@ export const Home: React.FC = () => {
       <Helmet />
       <Heading size="3xl" textAlign="center" marginTop={10}>
         Üdvözlünk a{' '}
-        <Heading as="span" color="brand.500" size="3xl">
+        <Heading as="span" color={useColorModeValue('brand.500', 'brand.600')} size="3xl">
           GólyaKörTe
         </Heading>{' '}
         portálon
@@ -117,9 +117,9 @@ const QuoteMark: React.FC<QuoteMarkProps> = ({ side, size }) => {
       right={side === 'right' ? 0 : undefined}
     >
       {side === 'left' ? (
-        <FaQuoteLeft size={size + 'rem'} color={customTheme.colors.brand['300']} />
+        <FaQuoteLeft size={size + 'rem'} color={useColorModeValue(customTheme.colors.brand['500'], customTheme.colors.brand['600'])} />
       ) : (
-        <FaQuoteRight size={size + 'rem'} color={customTheme.colors.brand['300']} />
+        <FaQuoteRight size={size + 'rem'} color={useColorModeValue(customTheme.colors.brand['500'], customTheme.colors.brand['600'])} />
       )}
     </Box>
   )

--- a/src/main/client/src/components/@pages/ProfilePage.tsx
+++ b/src/main/client/src/components/@pages/ProfilePage.tsx
@@ -144,7 +144,7 @@ export const ProfilePage: React.FC<ProfilePageProps> = (props) => {
                 fontWeight={500}
                 _hover={{
                   textDecoration: 'none',
-                  color: 'brand.500'
+                  color: useColorModeValue('brand.500', 'brand.600')
                 }}
               >
                 Bucketlist
@@ -203,7 +203,7 @@ export const ProfilePage: React.FC<ProfilePageProps> = (props) => {
                   fontWeight={500}
                   _hover={{
                     textDecoration: 'none',
-                    color: 'brand.500'
+                    color: useColorModeValue('brand.500', 'brand.600')
                   }}
                 >
                   {challenge.name}

--- a/src/main/client/src/utils/Loading.tsx
+++ b/src/main/client/src/utils/Loading.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Center, Spinner } from '@chakra-ui/react'
+import { Center, Spinner, useColorModeValue } from '@chakra-ui/react'
 
 type LoadingProps = {
   timeout?: number
@@ -23,7 +23,7 @@ export const Loading: React.FC<LoadingProps> = ({ timeout, children }) => {
     <>{children}</>
   ) : (
     <Center>
-      <Spinner color="brand.500" size="xl" thickness="0.3rem" />
+      <Spinner color={useColorModeValue('brand.500', 'brand.600')} size="xl" thickness="0.3rem" />
     </Center>
   )
 }

--- a/src/main/client/src/utils/customTheme.ts
+++ b/src/main/client/src/utils/customTheme.ts
@@ -1,9 +1,10 @@
 import { extendTheme } from '@chakra-ui/react'
-import { alertAnatomy as parts } from '@chakra-ui/anatomy'
-import { PartsStyleFunction, mode, SystemStyleFunction, transparentize } from '@chakra-ui/theme-tools'
+import { alertAnatomy as alertParts, progressAnatomy as progressParts } from '@chakra-ui/anatomy'
+import { PartsStyleFunction, mode, SystemStyleFunction, generateStripe, getColor, transparentize } from '@chakra-ui/theme-tools'
 
-// functions copied from https://github.com/chakra-ui/chakra-ui/blob/main/packages/theme/src/components/button.ts
-// (and alert.ts) then modified to our liking
+// functions copied from
+// https://github.com/chakra-ui/chakra-ui/blob/main/packages/theme/src/components/button.ts, alert.ts and progress.ts
+// then modified to our liking
 const buttonVariantGhost: SystemStyleFunction = (props) => {
   const { colorScheme: c, theme } = props
 
@@ -77,12 +78,34 @@ const buttonVariantOutline: SystemStyleFunction = (props) => {
   }
 }
 
-const alertVariantSolid: PartsStyleFunction<typeof parts> = (props) => {
+const alertVariantSolid: PartsStyleFunction<typeof alertParts> = (props) => {
   const { colorScheme: c } = props
   return {
     container: {
       bg: mode(`${c}.500`, `${c}.600`)(props),
       color: 'white'
+    }
+  }
+}
+
+const progressBaseStyle: PartsStyleFunction<typeof progressParts> = (props) => {
+  const { colorScheme: c, theme: t, isIndeterminate, hasStripe } = props
+  const stripeStyle = mode(generateStripe(), generateStripe('1rem', 'rgba(0,0,0,0.1)'))(props)
+  const bgColor = mode(`${c}.500`, `${c}.600`)(props)
+  const gradient = `linear-gradient(
+    to right,
+    transparent 0%,
+    ${getColor(t, bgColor)} 50%,
+    transparent 100%
+  )`
+  const addStripe = !isIndeterminate && hasStripe
+
+  return {
+    filledTrack: {
+      transitionProperty: 'common',
+      transitionDuration: 'slow',
+      ...(addStripe && stripeStyle),
+      ...(isIndeterminate ? { bgImage: gradient } : { bgColor })
     }
   }
 }
@@ -134,6 +157,9 @@ const customTheme = extendTheme({
       variants: {
         solid: alertVariantSolid
       }
+    },
+    Progress: {
+      baseStyle: progressBaseStyle
     }
   }
 })

--- a/src/main/client/src/utils/customTheme.ts
+++ b/src/main/client/src/utils/customTheme.ts
@@ -1,5 +1,91 @@
 import { extendTheme } from '@chakra-ui/react'
-import { mode, SystemStyleObject } from '@chakra-ui/theme-tools'
+import { alertAnatomy as parts } from '@chakra-ui/anatomy'
+import { PartsStyleFunction, mode, SystemStyleFunction, transparentize } from '@chakra-ui/theme-tools'
+
+// functions copied from https://github.com/chakra-ui/chakra-ui/blob/main/packages/theme/src/components/button.ts
+// (and alert.ts) then modified to our liking
+const buttonVariantGhost: SystemStyleFunction = (props) => {
+  const { colorScheme: c, theme } = props
+
+  if (c === 'gray') {
+    return {
+      color: mode(`inherit`, `whiteAlpha.900`)(props),
+      _hover: {
+        bg: mode(`gray.100`, `whiteAlpha.200`)(props)
+      },
+      _active: { bg: mode(`gray.200`, `whiteAlpha.300`)(props) }
+    }
+  }
+
+  const darkHoverBg = transparentize(`${c}.500`, 0.12)(theme)
+  const darkActiveBg = transparentize(`${c}.500`, 0.24)(theme)
+
+  return {
+    color: mode(`${c}.500`, `${c}.600`)(props),
+    bg: 'transparent',
+    _hover: {
+      bg: mode(`${c}.50`, darkHoverBg)(props)
+    },
+    _active: {
+      bg: mode(`${c}.100`, darkActiveBg)(props)
+    }
+  }
+}
+
+const buttonVariantSolid: SystemStyleFunction = (props) => {
+  const { colorScheme: c } = props
+  if (c === 'gray') {
+    const bg = mode(`gray.100`, `whiteAlpha.200`)(props)
+    return {
+      bg,
+      _hover: {
+        bg: mode(`gray.200`, `whiteAlpha.300`)(props),
+        _disabled: {
+          bg
+        }
+      },
+      _active: { bg: mode(`gray.300`, `whiteAlpha.400`)(props) }
+    }
+  }
+  const yellowOrCyan = c === 'yellow' || c === 'cyan'
+  const bg = yellowOrCyan ? `${c}.400` : `${c}.500`
+  const color = yellowOrCyan ? 'black' : 'white'
+  const hoverBg = yellowOrCyan ? `${c}.500` : `${c}.600`
+  const activeBg = yellowOrCyan ? `${c}.600` : `${c}.700`
+
+  const background = mode(bg, `${c}.700`)(props)
+  return {
+    bg: background,
+    color: mode(color, `whiteAlpha.900`)(props),
+    _hover: {
+      bg: mode(hoverBg, `${c}.600`)(props),
+      _disabled: {
+        bg: background
+      }
+    },
+    _active: { bg: mode(activeBg, `${c}.600`)(props) }
+  }
+}
+
+const buttonVariantOutline: SystemStyleFunction = (props) => {
+  const { colorScheme: c } = props
+  const borderColor = mode(`gray.200`, `whiteAlpha.300`)(props)
+  return {
+    border: '1px solid',
+    borderColor: c === 'gray' ? borderColor : 'currentColor',
+    ...buttonVariantGhost(props)
+  }
+}
+
+const alertVariantSolid: PartsStyleFunction<typeof parts> = (props) => {
+  const { colorScheme: c } = props
+  return {
+    container: {
+      bg: mode(`${c}.500`, `${c}.600`)(props),
+      color: 'white'
+    }
+  }
+}
 
 // See more: https://chakra-ui.com/docs/theming/customize-theme
 const customTheme = extendTheme({
@@ -13,6 +99,7 @@ const customTheme = extendTheme({
   },
   colors: {
     brand: {
+      50: '#d9fae7',
       100: '#d4f3e7',
       200: '#a8e7ce',
       300: '#7ddcb6',
@@ -38,40 +125,14 @@ const customTheme = extendTheme({
     },
     Button: {
       variants: {
-        solid: (props: SystemStyleObject) => {
-          const { colorScheme: c } = props
-          if (c === 'gray') {
-            const bg = mode(`gray.100`, `whiteAlpha.200`)(props)
-            return {
-              bg,
-              _hover: {
-                bg: mode(`gray.200`, `whiteAlpha.300`)(props),
-                _disabled: {
-                  bg
-                }
-              },
-              _active: { bg: mode(`gray.300`, `whiteAlpha.400`)(props) }
-            }
-          }
-          const yellowOrCyan = c === 'yellow' || c === 'cyan'
-          const bg = yellowOrCyan ? `${c}.400` : `${c}.500`
-          const color = yellowOrCyan ? 'black' : 'white'
-          const hoverBg = yellowOrCyan ? `${c}.500` : `${c}.600`
-          const activeBg = yellowOrCyan ? `${c}.600` : `${c}.700`
-
-          const background = mode(bg, `${c}.700`)(props)
-          return {
-            bg: background,
-            color: mode(color, `whiteAlpha.900`)(props),
-            _hover: {
-              bg: mode(hoverBg, `${c}.600`)(props),
-              _disabled: {
-                bg: background
-              }
-            },
-            _active: { bg: mode(activeBg, `${c}.600`)(props) }
-          }
-        }
+        solid: buttonVariantSolid,
+        ghost: buttonVariantGhost,
+        outline: buttonVariantOutline
+      }
+    },
+    Alert: {
+      variants: {
+        solid: alertVariantSolid
       }
     }
   }


### PR DESCRIPTION
- Everything that's green on the site uses 'brand.500' in light mode and 'brand.600' in dark mode.
- The only exception is the hover of the achievement and riddle items, that remained 'brand.300' and 'brand.700' (the default colors would be too vibrant here because these are pretty big)
- Had to overwrite the ghost and outline variants of the Button component, the subtle variant of the Alert component (because Toast uses this), and the Progress component.
- Outline and ghost variants of Button have a subtle hover color
- The button that toggles the Navbar on mobile is no longer green, but the default color like the button that toggles the theme
- Closes #206 
![image](https://user-images.githubusercontent.com/13004605/152790818-94d01999-3d5e-4c9f-886a-782d59a80e7f.png)
The QR-stamps button is hovered
![image](https://user-images.githubusercontent.com/13004605/152790830-f576b80c-d924-4bc6-9911-66448e50deb3.png)
![image](https://user-images.githubusercontent.com/13004605/152790837-fba4b52b-16c4-45b7-b27e-73df10b5b437.png)
