### PR TITLE
kszk signup links and no more NaN on profile page

### DIFF
--- a/src/main/client/src/components/@pages/ProfilePage.tsx
+++ b/src/main/client/src/components/@pages/ProfilePage.tsx
@@ -31,13 +31,15 @@ const challenges = (profile: ProfileDTO) => [
     name: 'Riddle',
     completed: profile?.completedRiddleCount,
     total: profile?.totalRiddleCount,
-    link: '/riddleok'
+    link: '/riddleok',
+    percentage: profile?.totalRiddleCount === 0 ? 0 : (profile?.completedRiddleCount / profile?.totalRiddleCount) * 100
   },
   {
     name: 'QR kód',
     completed: profile?.tokens?.length,
     total: profile?.totalTokenCount,
-    link: '/qr'
+    link: '/qr',
+    percentage: profile?.totalTokenCount === 0 ? 0 : (profile?.tokens?.length / profile?.totalTokenCount) * 100
   }
 ]
 
@@ -203,11 +205,11 @@ export const ProfilePage: React.FC<ProfilePageProps> = (props) => {
               <CircularProgress
                 color={useColorModeValue('brand.500', 'brand.600')}
                 size="10rem"
-                value={(challenge.completed / challenge.total) * 100}
+                value={challenge.percentage}
                 trackColor={useColorModeValue('gray.200', 'gray.700')}
               >
                 <CircularProgressLabel color={challenge.completed === 0 ? 'gray.500' : useColorModeValue('brand.500', 'brand.600')}>
-                  {Math.round((challenge.completed / challenge.total) * 100)}%
+                  {Math.round(challenge.percentage)}%
                 </CircularProgressLabel>
               </CircularProgress>
             </Flex>

--- a/src/main/client/src/content/communities.ts
+++ b/src/main/client/src/content/communities.ts
@@ -177,6 +177,7 @@ export const COMMUNITIES: Community[] = [
       a képességeinek megfelelő elfoglaltságot.`
     ],
     resortId: 'kszk',
+    application: 'https://ujonc.kszk.bme.hu',
     logo: '/img/communities/devteam.svg'
   },
   {
@@ -354,6 +355,7 @@ export const COMMUNITIES: Community[] = [
     (rosszabb napjain) napi ötezer oldalmegtekintést produkáló rendszer karbantartásától, fejlesztésétől.`
     ],
     resortId: 'kszk',
+    application: 'https://ujonc.kszk.bme.hu',
     logo: '/img/communities/hat.svg'
   },
   {
@@ -610,6 +612,7 @@ export const COMMUNITIES: Community[] = [
       tényező tud lenni, amivel kevés frissen végzett hálózati szakember rendelkezik.`
     ],
     resortId: 'kszk',
+    application: 'https://ujonc.kszk.bme.hu',
     logo: '/img/communities/neteam.svg'
   },
   {
@@ -780,6 +783,7 @@ export const COMMUNITIES: Community[] = [
       minden ősszel rendezünk meg, a Wargame.`
     ],
     resortId: 'kszk',
+    application: 'https://ujonc.kszk.bme.hu',
     logo: '/img/communities/securiteam.svg'
   },
   {
@@ -857,6 +861,7 @@ export const COMMUNITIES: Community[] = [
       ne csüggedj: az előismeret nem követelmény, a lelkesedés igen.`
     ],
     resortId: 'kszk',
+    application: 'https://ujonc.kszk.bme.hu',
     logo: '/img/communities/sysadmin.svg'
   },
   {


### PR DESCRIPTION
- Closes #223
- 0% instead of NaN% on the profile page for riddles and qr codes as well (#226 only fixed it for bucketlist)