### PR TITLE
Count only the default tokens in progress

### DIFF
--- a/src/main/client/src/components/@pages/ProfilePage.tsx
+++ b/src/main/client/src/components/@pages/ProfilePage.tsx
@@ -36,10 +36,10 @@ const challenges = (profile: ProfileDTO) => [
   },
   {
     name: 'QR kód',
-    completed: profile?.tokens?.length,
+    completed: profile?.collectedTokenCount,
     total: profile?.totalTokenCount,
     link: '/qr',
-    percentage: profile?.totalTokenCount === 0 ? 0 : (profile?.tokens?.length / profile?.totalTokenCount) * 100
+    percentage: profile?.totalTokenCount === 0 ? 0 : (profile?.collectedTokenCount / profile?.totalTokenCount) * 100
   }
 ]
 

--- a/src/main/client/src/components/@pages/QRList.tsx
+++ b/src/main/client/src/components/@pages/QRList.tsx
@@ -41,7 +41,7 @@ export const QRList: React.FC = (props) => {
           tokens: profile.tokens,
           minTokenToComplete: profile.minTokenToComplete,
           totalTokenCount: profile.totalTokenCount,
-          acquiredTokenCount: profile.tokens.filter((token) => token.type === 'default').length
+          acquiredTokenCount: profile.collectedTokenCount
         })
         setLoading(false)
       })

--- a/src/main/client/src/types/dto/profile.ts
+++ b/src/main/client/src/types/dto/profile.ts
@@ -6,6 +6,7 @@ export interface ProfileDTO {
   role: keyof typeof RoleType
   tokens: TokenDTO[]
   totalTokenCount: number
+  collectedTokenCount: number
   totalRiddleCount: number
   completedRiddleCount: number
   totalAchievementCount: number


### PR DESCRIPTION
`collectedTokenCount` wasn't even used in the frontend before
There are 4 default and one extra token in the mock data, and this is how it looks after scanning one default and one extra:
![image](https://user-images.githubusercontent.com/13004605/154753480-92526665-fd0d-4259-8202-7c33cb757ffc.png)
![image](https://user-images.githubusercontent.com/13004605/154753485-2c306260-5189-4b50-a94e-8b317742d988.png)
