### PR TITLE
Config based styling

### DIFF
--- a/frontend/src/api/contexts/config/ConfigContext.tsx
+++ b/frontend/src/api/contexts/config/ConfigContext.tsx
@@ -2,13 +2,13 @@ import { createContext, useContext } from 'react'
 import { HasChildren } from '../../../util/react-types.util'
 import { ConfigDto } from './types'
 import { useConfigQuery } from '../../hooks/useConfigQuery'
+import { Loading } from '../../../common-components/Loading'
 
 export const ConfigContext = createContext<ConfigDto | undefined>(undefined)
 
 export const ConfigProvider = ({ children }: HasChildren) => {
   const { data, isLoading } = useConfigQuery((err) => console.error('[ERROR] at ConfigProvider', JSON.stringify(err, null, 2)))
-  // TODO: add loading screen
-  if (isLoading) return null
+  if (isLoading) return <Loading />
   return <ConfigContext.Provider value={data}>{children}</ConfigContext.Provider>
 }
 

--- a/frontend/src/api/contexts/config/types.ts
+++ b/frontend/src/api/contexts/config/types.ts
@@ -126,18 +126,26 @@ export interface Profile {
 }
 
 export interface Style {
-  backgroundColor: string
-  textColor: string
-  textColorAccent: string
-  brandingColor: string
-  backgroundUrl: string
-  mobileBackgroundUrl: string
+  lightBackgroundColor: string
+  lightContainerColor: string
+  lightTextColor: string
+  lightBrandingColor: string
+  lightBackgroundUrl: string
+  lightMobileBackgroundUrl: string
+  darkModeEnabled: boolean
+  deviceTheme: boolean
+  darkBackgroundColor: string
+  darkContainerColor: string
+  darkTextColor: string
+  darkBrandingColor: string
+  darkBackgroundUrl: string
+  darkMobileBackgroundUrl: string
   mainFontName: string
   mainFontCdn: string
-  mainFontWeight: string
+  mainFontWeight: number
   displayFontName: string
   displayFontCdn: string
-  displayFontWeight: string
+  displayFontWeight: number
 }
 
 export interface Task {

--- a/frontend/src/api/contexts/themeConfig/ThemeConfig.tsx
+++ b/frontend/src/api/contexts/themeConfig/ThemeConfig.tsx
@@ -5,12 +5,11 @@ import { ChakraProvider } from '@chakra-ui/react'
 import Values from 'values.js'
 import { useMemo } from 'react'
 import { mode } from '@chakra-ui/theme-tools'
-import { Global } from '@emotion/react'
+import { Helmet } from 'react-helmet'
 
 export const ThemeConfig = ({ children }: HasChildren) => {
   const config = useConfigContext()
   const chakraConfig = useMemo(() => {
-    let Fonts = null
     if (config) {
       customTheme.colors.brand = getColorShadesForColor(config.components.style.brandingColor)
       customTheme.colors.accent = config.components.style.textColorAccent
@@ -21,48 +20,31 @@ export const ThemeConfig = ({ children }: HasChildren) => {
       customTheme.styles.global = (props: any) => ({
         body: {
           bg: mode(backgrounds.light.hexString(), backgrounds.dark.hexString())(props),
-          color: mode(texts.dark.hexString(), texts.light.hexString())(props)
+          color: mode(texts.dark.hexString(), texts.light.hexString())(props),
+          bgImage: `url(${config.components.style.backgroundUrl})`,
+          [`@media screen and (max-width: ${props.theme.breakpoints.sm})`]: {
+            bgImage: `url(${config.components.style.mobileBackgroundUrl})`
+          }
         }
       })
       customTheme.fonts = {
-        heading: config.components.style.mainFontName,
-        display: config.components.style.displayFontName
+        heading: config.components.style.displayFontName,
+        body: config.components.style.mainFontName
       }
-
-      Fonts = () => (
-        <Global
-          styles={`
-            /* latin */
-            @font-face {
-              font-family: ${config.components.style.mainFontName};
-              font-style: normal;
-              font-weight: ${config.components.style.mainFontWeight};
-              font-display: swap;
-              src: url(${config.components.style.mainFontCdn}) format('woff2'), url(${config.components.style.mainFontCdn}) format('woff');
-              unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074,
-               U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-            }
-            /* latin */
-            @font-face {
-              font-family: 'display';
-              font-style: normal;
-              font-weight: ${config.components.style.displayFontWeight};
-              font-display: swap;
-              src: url(${config.components.style.displayFontCdn}) format('woff2'),
-                url(${config.components.style.displayFontCdn}) format('woff');
-              unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074,
-              U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-            }
-            `}
-        />
-      )
     }
-    return { theme: customTheme, fonts: Fonts }
+    return customTheme
   }, [config])
   return (
-    <ChakraProvider theme={chakraConfig.theme}>
+    <ChakraProvider theme={chakraConfig}>
       <>
-        {chakraConfig.fonts}
+        {(config?.components.style.mainFontCdn || config?.components.style.displayFontCdn) && (
+          <Helmet>
+            <link rel="preconnect" href="https://fonts.googleapis.com" />
+            <link rel="preconnect" href="https://fonts.gstatic.com" />
+            <link href={config?.components.style.displayFontCdn} rel="stylesheet" />
+            <link href={config?.components.style.mainFontCdn} rel="stylesheet" />
+          </Helmet>
+        )}
         {children}
       </>
     </ChakraProvider>

--- a/frontend/src/api/contexts/themeConfig/ThemeConfig.tsx
+++ b/frontend/src/api/contexts/themeConfig/ThemeConfig.tsx
@@ -4,15 +4,69 @@ import { useConfigContext } from '../config/ConfigContext'
 import { ChakraProvider } from '@chakra-ui/react'
 import Values from 'values.js'
 import { useMemo } from 'react'
+import { mode } from '@chakra-ui/theme-tools'
+import { Global } from '@emotion/react'
 
 export const ThemeConfig = ({ children }: HasChildren) => {
   const config = useConfigContext()
-  // TODO: Should overwrite more fields if API supports it
   const chakraConfig = useMemo(() => {
-    if (config) customTheme.colors.brand = getColorShadesForColor(config.components.style.brandingColor)
-    return customTheme
+    let Fonts = null
+    if (config) {
+      customTheme.colors.brand = getColorShadesForColor(config.components.style.brandingColor)
+      customTheme.colors.accent = config.components.style.textColorAccent
+      const bgColor = new Values(config.components.style.backgroundColor)
+      const textColor = new Values(config.components.style.textColor)
+      const backgrounds = getOppositeColor(bgColor, 90)
+      const texts = getOppositeColor(textColor, 1000)
+      customTheme.styles.global = (props: any) => ({
+        body: {
+          bg: mode(backgrounds.light.hexString(), backgrounds.dark.hexString())(props),
+          color: mode(texts.dark.hexString(), texts.light.hexString())(props)
+        }
+      })
+      customTheme.fonts = {
+        heading: config.components.style.mainFontName,
+        display: config.components.style.displayFontName
+      }
+
+      Fonts = () => (
+        <Global
+          styles={`
+            /* latin */
+            @font-face {
+              font-family: ${config.components.style.mainFontName};
+              font-style: normal;
+              font-weight: ${config.components.style.mainFontWeight};
+              font-display: swap;
+              src: url(${config.components.style.mainFontCdn}) format('woff2'), url(${config.components.style.mainFontCdn}) format('woff');
+              unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074,
+               U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+            }
+            /* latin */
+            @font-face {
+              font-family: 'display';
+              font-style: normal;
+              font-weight: ${config.components.style.displayFontWeight};
+              font-display: swap;
+              src: url(${config.components.style.displayFontCdn}) format('woff2'),
+                url(${config.components.style.displayFontCdn}) format('woff');
+              unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074,
+              U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+            }
+            `}
+        />
+      )
+    }
+    return { theme: customTheme, fonts: Fonts }
   }, [config])
-  return <ChakraProvider theme={chakraConfig}>{children}</ChakraProvider>
+  return (
+    <ChakraProvider theme={chakraConfig.theme}>
+      <>
+        {chakraConfig.fonts}
+        {children}
+      </>
+    </ChakraProvider>
+  )
 }
 
 function getColorShadesForColor(color: string) {
@@ -28,4 +82,12 @@ function getColorShadesForColor(color: string) {
     result[(i + 6) * 100] = t.hexString()
   })
   return result
+}
+
+function getOppositeColor(color: Values, weight: number): { light: Values; dark: Values } {
+  if (color.getBrightness() < 50) {
+    return { light: color.tint(weight), dark: color }
+  } else {
+    return { light: color, dark: color.shade(weight) }
+  }
 }

--- a/frontend/src/api/contexts/themeConfig/ThemeConfig.tsx
+++ b/frontend/src/api/contexts/themeConfig/ThemeConfig.tsx
@@ -11,19 +11,21 @@ export const ThemeConfig = ({ children }: HasChildren) => {
   const config = useConfigContext()
   const chakraConfig = useMemo(() => {
     if (config) {
-      customTheme.colors.brand = getColorShadesForColor(config.components.style.brandingColor)
-      customTheme.colors.accent = config.components.style.textColorAccent
-      const bgColor = new Values(config.components.style.backgroundColor)
-      const textColor = new Values(config.components.style.textColor)
-      const backgrounds = getOppositeColor(bgColor, 90)
-      const texts = getOppositeColor(textColor, 1000)
+      customTheme.colors.brand = getColorShadesForColor(config.components.style.lightBrandingColor)
+      customTheme.colors.lightContainerBg = config.components.style.lightContainerColor
+      customTheme.colors.darkContainerBg = config.components.style.darkContainerColor
+      customTheme.initialColorMode = config.components.style.deviceTheme ? 'system' : 'light'
       customTheme.styles.global = (props: any) => ({
         body: {
-          bg: mode(backgrounds.light.hexString(), backgrounds.dark.hexString())(props),
-          color: mode(texts.dark.hexString(), texts.light.hexString())(props),
-          bgImage: `url(${config.components.style.backgroundUrl})`,
+          bg: mode(config.components.style.lightBackgroundColor, config.components.style.darkBackgroundColor)(props),
+          color: mode(config.components.style.lightTextColor, config.components.style.darkTextColor)(props),
+          bgImage: mode(`url(${config.components.style.lightBackgroundUrl})`, `url(${config.components.style.darkBackgroundUrl})`)(props),
+          bgRepeat: 'no-repeat',
           [`@media screen and (max-width: ${props.theme.breakpoints.sm})`]: {
-            bgImage: `url(${config.components.style.mobileBackgroundUrl})`
+            bgImage: mode(
+              `url(${config.components.style.lightMobileBackgroundUrl})`,
+              `url(${config.components.style.darkMobileBackgroundUrl})`
+            )
           }
         }
       })
@@ -64,12 +66,4 @@ function getColorShadesForColor(color: string) {
     result[(i + 6) * 100] = t.hexString()
   })
   return result
-}
-
-function getOppositeColor(color: Values, weight: number): { light: Values; dark: Values } {
-  if (color.getBrightness() < 50) {
-    return { light: color.tint(weight), dark: color }
-  } else {
-    return { light: color, dark: color.shade(weight) }
-  }
 }

--- a/frontend/src/common-components/layout/CmschContainer.tsx
+++ b/frontend/src/common-components/layout/CmschContainer.tsx
@@ -1,11 +1,17 @@
-import * as React from 'react'
-import { Flex } from '@chakra-ui/react'
+import { Flex, useColorModeValue } from '@chakra-ui/react'
 import { HasChildren } from '../../util/react-types.util'
 
 type Props = {} & HasChildren
 
 export const CmschContainer = ({ children }: Props) => (
-  <Flex flexDirection="column" px="4" mx="auto" maxWidth={['100%', '48rem', '48rem', '64rem']}>
+  <Flex
+    flexDirection="column"
+    px="4"
+    py="4"
+    mx="auto"
+    maxWidth={['100%', '48rem', '48rem', '64rem']}
+    bg={useColorModeValue('lightContainerBg', 'darkContainerBg')}
+  >
     {children}
   </Flex>
 )

--- a/frontend/src/common-components/navigation/ColorModeSwitcher.tsx
+++ b/frontend/src/common-components/navigation/ColorModeSwitcher.tsx
@@ -1,12 +1,14 @@
 import { MoonIcon, SunIcon } from '@chakra-ui/icons'
 import { IconButton, IconButtonProps, useColorMode, useColorModeValue } from '@chakra-ui/react'
+import { useConfigContext } from '../../api/contexts/config/ConfigContext'
 
 type Props = Omit<IconButtonProps, 'aria-label'>
 
 export const ColorModeSwitcher = (props: Props) => {
   const { toggleColorMode } = useColorMode()
+  const config = useConfigContext()
 
-  return (
+  return config?.components.style.darkModeEnabled ? (
     <IconButton
       aria-label="Sötét-világos mód váltás"
       icon={useColorModeValue(<SunIcon w={5} h={5} />, <MoonIcon w={5} h={5} />)}
@@ -14,5 +16,5 @@ export const ColorModeSwitcher = (props: Props) => {
       variant="ghost"
       {...props}
     />
-  )
+  ) : null
 }

--- a/frontend/src/pages/index/index.page.tsx
+++ b/frontend/src/pages/index/index.page.tsx
@@ -38,7 +38,7 @@ const IndexPage = () => {
   return (
     <CmschPage>
       <Helmet />
-      <Heading size="3xl" textAlign="center" marginTop={10} color="accent">
+      <Heading size="3xl" textAlign="center" marginTop={10}>
         Üdvözlünk a{' '}
         <Heading as="span" color={useColorModeValue('brand.500', 'brand.600')} size="3xl">
           {config?.components.app.siteName || 'CMSch'}

--- a/frontend/src/pages/index/index.page.tsx
+++ b/frontend/src/pages/index/index.page.tsx
@@ -38,7 +38,7 @@ const IndexPage = () => {
   return (
     <CmschPage>
       <Helmet />
-      <Heading size="3xl" textAlign="center" marginTop={10}>
+      <Heading size="3xl" textAlign="center" marginTop={10} color="accent">
         Üdvözlünk a{' '}
         <Heading as="span" color={useColorModeValue('brand.500', 'brand.600')} size="3xl">
           {config?.components.app.siteName || 'CMSch'}


### PR DESCRIPTION
For some reason I can only change the font of the headings on the site, nothing else, but I think it's better if we don't let them change a font that might be used on long texts.
I think we should ask for darkmode background colors and background images as well. I tried inverting the background color in dark mode, but it usually doesn't look too good, and it's even worse with the background image (becasue it stays the same in dark mode, but the text color changes).

Closes #342 