### PR TITLE
Move organizers to home page

### DIFF
--- a/frontend/src/pages/home/home.page.tsx
+++ b/frontend/src/pages/home/home.page.tsx
@@ -12,10 +12,13 @@ import { LinkButton } from '../../common-components/LinkButton'
 import Markdown from '../../common-components/Markdown'
 import { EmbeddedVideo } from './components/EmbeddedVideo'
 import { l } from '../../util/language'
+import { OrganizerSection } from '../impressum/components/OrganizerSection'
 
 const HomePage = () => {
   const eventList = useEventListQuery(() => console.log('Event list query failed!'))
   const config = useConfigContext()
+
+  const impressumConfig = config?.components?.impressum
 
   const countTo = useMemo(() => {
     const component = config?.components.countdown
@@ -103,6 +106,22 @@ const HomePage = () => {
           </VStack>
         </VStack>
       )}
+
+      <Box my={4}>
+        <Heading size="3xl" textAlign="center">
+          Akikhez fordulhatsz segítségért a versenyen
+        </Heading>
+        <OrganizerSection
+          organizers={impressumConfig?.leadOrganizers || []}
+          message={impressumConfig?.leadOrganizersMessage}
+          title="Rendezők"
+        />
+        <OrganizerSection
+          organizers={impressumConfig?.otherOrganizers || []}
+          message={impressumConfig?.otherOrganizersMessage}
+          title="Stáb további tagjai"
+        />
+      </Box>
     </CmschPage>
   )
 }

--- a/frontend/src/pages/impressum/impressum.page.tsx
+++ b/frontend/src/pages/impressum/impressum.page.tsx
@@ -4,7 +4,6 @@ import { useConfigContext } from '../../api/contexts/config/ConfigContext'
 import { CmschPage } from '../../common-components/layout/CmschPage'
 import Markdown from '../../common-components/Markdown'
 import { useDevelopers } from '../../api/hooks/useDevelopers'
-import { OrganizerSection } from './components/OrganizerSection'
 import { DeveloperWrapItem } from './components/DeveloperWrapItem'
 
 const ImpressumPage = () => {
@@ -26,16 +25,6 @@ const ImpressumPage = () => {
         ))}
       </Wrap>
       <Markdown text={impressumConfig?.developersBottomMessage} />
-      <OrganizerSection
-        organizers={impressumConfig?.leadOrganizers || []}
-        message={impressumConfig?.leadOrganizersMessage}
-        title="Rendezők"
-      />
-      <OrganizerSection
-        organizers={impressumConfig?.otherOrganizers || []}
-        message={impressumConfig?.otherOrganizersMessage}
-        title="Stáb további tagjai"
-      />
     </CmschPage>
   )
 }


### PR DESCRIPTION
Target branch: only the `deploy/hackathon-live`, we need this information on the front page.