### PR TITLE
More navbar & footer styling  options - frontend

### DIFF
--- a/frontend/src/api/contexts/config/types.ts
+++ b/frontend/src/api/contexts/config/types.ts
@@ -226,6 +226,10 @@ export interface Style {
   displayFontName: string
   displayFontCdn: string
   displayFontWeight: number
+  lightFooterTransparent: boolean
+  lightNavbarTransparent: boolean
+  darkFooterTransparent: boolean
+  darkNavbarTransparent: boolean
 }
 
 export interface Task {

--- a/frontend/src/api/contexts/themeConfig/ThemeConfig.tsx
+++ b/frontend/src/api/contexts/themeConfig/ThemeConfig.tsx
@@ -17,9 +17,15 @@ export const ThemeConfig = ({ children }: PropsWithChildren) => {
       customTheme.colors.darkContainerBg = config.components.style.darkContainerColor
       setColorMode((config.components.style.deviceTheme && 'system') || (config.components.style.forceDarkMode && 'dark') || 'light')
       customTheme.fonts = {
-        heading: config.components.style.displayFontName,
+        heading: config.components.style.mainFontName,
         body: config.components.style.mainFontName,
         mono: 'monospace'
+      }
+      customTheme.components.Heading = {
+        ...customTheme.components.Heading,
+        variants: {
+          'main-title': { fontFamily: config.components.style.displayFontName }
+        }
       }
     }
     return customTheme

--- a/frontend/src/common-components/chakra-md-renderer.tsx
+++ b/frontend/src/common-components/chakra-md-renderer.tsx
@@ -119,7 +119,7 @@ export const defaults: Components = {
   },
   h1: (props) => {
     return (
-      <Heading my={4} as="h1" size="2xl" {...getCoreProps(props)}>
+      <Heading my={4} as="h1" variant="main-title" size="2xl" {...getCoreProps(props)}>
         {props.children}
       </Heading>
     )

--- a/frontend/src/common-components/footer/Footer.tsx
+++ b/frontend/src/common-components/footer/Footer.tsx
@@ -17,8 +17,18 @@ export const Footer = () => {
   if (!component) return null
   const partnersVisible = component?.bmeEnabled || component?.vikEnabled || component?.schonherzEnabled || component?.schdesignEnabled
   const topBarVisible = (component?.sponsorsEnabled || partnersVisible) && !component.minimalisticFooter
+  const transparentNavbar = useColorModeValue(config.components.style.lightFooterTransparent, config.components.style.darkFooterTransparent)
   return (
-    <Flex flexDirection="column" align="center" w="full" bg={useColorModeValue('lightContainerBg', 'darkContainerBg')}>
+    <Flex
+      flexDirection="column"
+      align="center"
+      w="full"
+      bg={
+        transparentNavbar
+          ? useColorModeValue(config.components.style.lightContainerColor, config.components.style.darkContainerColor) + '50'
+          : useColorModeValue('lightContainerBg', 'darkContainerBg')
+      }
+    >
       {topBarVisible && (
         <Flex justify="center" w="full" bg={bgShadowColor} p={5}>
           <Flex
@@ -85,7 +95,7 @@ export const Footer = () => {
           />
         </Flex>
       </Flex>
-      <Text w="full" textAlign="center" p={3} bg={bgShadowColor}>
+      <Text w="full" textAlign="center" p={3} bg={transparentNavbar ? undefined : bgShadowColor}>
         Made with <FaHeart style={{ display: 'inline' }} color="red" size="1rem" /> by Kir-Dev <br /> Minden jog fenntartva. &copy;{' '}
         {new Date().getFullYear()}
       </Text>

--- a/frontend/src/common-components/navigation/Navbar.tsx
+++ b/frontend/src/common-components/navigation/Navbar.tsx
@@ -46,7 +46,7 @@ export const Navbar = () => {
             {logoUrl ? (
               <Image maxH={16} maxW={28} src={logoUrl} alt={config?.components.app.siteName} />
             ) : (
-              <Heading as="h1" my={2}>
+              <Heading as="h1" variant="main-title" my={2}>
                 {config?.components.app.siteName}
               </Heading>
             )}

--- a/frontend/src/common-components/navigation/Navbar.tsx
+++ b/frontend/src/common-components/navigation/Navbar.tsx
@@ -17,7 +17,11 @@ export const Navbar = () => {
       maxWidth={['100%', '64rem']}
       w="full"
       fontFamily="heading"
-      bg={config.components.style.darkContainerColor}
+      bg={
+        useColorModeValue(config.components.style.lightNavbarTransparent, config.components.style.darkNavbarTransparent)
+          ? undefined
+          : useColorModeValue(config.components.style.lightContainerColor, config.components.style.darkContainerColor)
+      }
       borderBottomRadius={[0, null, 'xl']}
       mb={4}
     >

--- a/frontend/src/common-components/navigation/Navbar.tsx
+++ b/frontend/src/common-components/navigation/Navbar.tsx
@@ -42,7 +42,9 @@ export const Navbar = () => {
             {logoUrl ? (
               <Image maxH={16} maxW={28} src={logoUrl} alt={config?.components.app.siteName} />
             ) : (
-              <Heading my={2}>{config?.components.app.siteName}</Heading>
+              <Heading as="h1" my={2}>
+                {config?.components.app.siteName}
+              </Heading>
             )}
           </Link>
         </Flex>

--- a/frontend/src/pages/access-key/accessKey.page.tsx
+++ b/frontend/src/pages/access-key/accessKey.page.tsx
@@ -66,7 +66,7 @@ function AccessKeyPage() {
   return (
     <CmschPage>
       <Helmet title={query.data.title} />
-      <Heading>{query.data.title}</Heading>
+      <Heading as="h1">{query.data.title}</Heading>
 
       {query.data.enabled ? (
         <Markdown text={query.data.topMessage} />

--- a/frontend/src/pages/access-key/accessKey.page.tsx
+++ b/frontend/src/pages/access-key/accessKey.page.tsx
@@ -66,7 +66,9 @@ function AccessKeyPage() {
   return (
     <CmschPage>
       <Helmet title={query.data.title} />
-      <Heading as="h1">{query.data.title}</Heading>
+      <Heading as="h1" variant="main-title">
+        {query.data.title}
+      </Heading>
 
       {query.data.enabled ? (
         <Markdown text={query.data.topMessage} />

--- a/frontend/src/pages/communities/communityList.page.tsx
+++ b/frontend/src/pages/communities/communityList.page.tsx
@@ -44,7 +44,7 @@ export default function CommunityListPage() {
   return (
     <CmschPage>
       <Helmet title={l('community-title')} />
-      <Heading>{l('community-title')}</Heading>
+      <Heading as="h1">{l('community-title')}</Heading>
       <InputGroup mt={5}>
         <InputLeftElement h="100%">
           <SearchIcon />

--- a/frontend/src/pages/communities/communityList.page.tsx
+++ b/frontend/src/pages/communities/communityList.page.tsx
@@ -44,7 +44,9 @@ export default function CommunityListPage() {
   return (
     <CmschPage>
       <Helmet title={l('community-title')} />
-      <Heading as="h1">{l('community-title')}</Heading>
+      <Heading as="h1" variant="main-title">
+        {l('community-title')}
+      </Heading>
       <InputGroup mt={5}>
         <InputLeftElement h="100%">
           <SearchIcon />

--- a/frontend/src/pages/communities/organizationList.page.tsx
+++ b/frontend/src/pages/communities/organizationList.page.tsx
@@ -42,7 +42,9 @@ export default function OrganizationListPage() {
   return (
     <CmschPage>
       <Helmet title={l('organization-title')} />
-      <Heading as="h1">{l('organization-title')}</Heading>
+      <Heading as="h1" variant="main-title">
+        {l('organization-title')}
+      </Heading>
       <InputGroup mt={5}>
         <InputLeftElement h="100%">
           <SearchIcon />

--- a/frontend/src/pages/communities/organizationList.page.tsx
+++ b/frontend/src/pages/communities/organizationList.page.tsx
@@ -42,7 +42,7 @@ export default function OrganizationListPage() {
   return (
     <CmschPage>
       <Helmet title={l('organization-title')} />
-      <Heading>{l('organization-title')}</Heading>
+      <Heading as="h1">{l('organization-title')}</Heading>
       <InputGroup mt={5}>
         <InputLeftElement h="100%">
           <SearchIcon />

--- a/frontend/src/pages/error/error.page.tsx
+++ b/frontend/src/pages/error/error.page.tsx
@@ -33,7 +33,9 @@ export const ErrorPage = ({ message: messageProp }: Props) => {
   return (
     <CmschPage>
       <Helmet title={l('error-page-helmet')} />
-      <Heading textAlign="center">{l('error-page-title')}</Heading>
+      <Heading as="h1" textAlign="center">
+        {l('error-page-title')}
+      </Heading>
       <Box textAlign="center" color="gray.500" marginTop={10}>
         <Markdown text={clonedMessage} />
       </Box>

--- a/frontend/src/pages/error/error.page.tsx
+++ b/frontend/src/pages/error/error.page.tsx
@@ -33,7 +33,7 @@ export const ErrorPage = ({ message: messageProp }: Props) => {
   return (
     <CmschPage>
       <Helmet title={l('error-page-helmet')} />
-      <Heading as="h1" textAlign="center">
+      <Heading as="h1" variant="main-title" textAlign="center">
         {l('error-page-title')}
       </Heading>
       <Box textAlign="center" color="gray.500" marginTop={10}>

--- a/frontend/src/pages/error/unauthorized.page.tsx
+++ b/frontend/src/pages/error/unauthorized.page.tsx
@@ -11,7 +11,9 @@ export const UnauthorizedPage = () => {
   return (
     <CmschPage>
       <Helmet title={l('unauthorized-page-helmet')} />
-      <Heading textAlign="center">{l('unauthorized-page-title')}</Heading>
+      <Heading as="h1" textAlign="center">
+        {l('unauthorized-page-title')}
+      </Heading>
       <Text textAlign="center" color="gray.500" marginTop={10}>
         {l('unauthorized-page-description')}
       </Text>

--- a/frontend/src/pages/error/unauthorized.page.tsx
+++ b/frontend/src/pages/error/unauthorized.page.tsx
@@ -11,7 +11,7 @@ export const UnauthorizedPage = () => {
   return (
     <CmschPage>
       <Helmet title={l('unauthorized-page-helmet')} />
-      <Heading as="h1" textAlign="center">
+      <Heading as="h1" variant="main-title" textAlign="center">
         {l('unauthorized-page-title')}
       </Heading>
       <Text textAlign="center" color="gray.500" marginTop={10}>

--- a/frontend/src/pages/events/components/event-calendar/DayCalendar.tsx
+++ b/frontend/src/pages/events/components/event-calendar/DayCalendar.tsx
@@ -41,11 +41,11 @@ export function DayCalendar({ events }: DayCalendarProps) {
   return (
     <Box my={5} w="full" display={['block', null, 'none']}>
       <HStack justify="space-between">
-        <IconButton aria-label="Előző nap" icon={<FaChevronLeft />} onClick={decrementDay} />
+        <IconButton colorScheme="brand" aria-label="Előző nap" icon={<FaChevronLeft />} onClick={decrementDay} />
         <Heading as="h2" size="md">
           {formatHu(startDate, 'EEEE, MMMM dd.')}
         </Heading>
-        <IconButton aria-label="Következő nap" icon={<FaChevronRight />} onClick={incrementDay} />
+        <IconButton colorScheme="brand" aria-label="Következő nap" icon={<FaChevronRight />} onClick={incrementDay} />
       </HStack>
       <ZoomBar incrementScale={incrementScale} decrementScale={decrementScale} scale={scale} />
       <HStack maxH={820} mt={5} overflowY="auto" overflowX="hidden" pt={5} align="flex-start">

--- a/frontend/src/pages/events/components/event-calendar/WeekCalendar.tsx
+++ b/frontend/src/pages/events/components/event-calendar/WeekCalendar.tsx
@@ -51,11 +51,11 @@ export function WeekCalendar({ events }: WeekCalendarProps) {
   return (
     <Box my={5} w="full" display={['none', null, 'block']}>
       <HStack justify="space-between">
-        <IconButton aria-label="Előző hét" icon={<FaChevronLeft />} onClick={decrementWeek} />
+        <IconButton colorScheme="brand" aria-label="Előző hét" icon={<FaChevronLeft />} onClick={decrementWeek} />
         <Heading as="h2" size="md">
           {formatHu(startDate, 'MM. dd.')} - {formatHu(days[days.length - 1].date, 'MM. dd.')}
         </Heading>
-        <IconButton aria-label="Következő hét" icon={<FaChevronRight />} onClick={incrementWeek} />
+        <IconButton colorScheme="brand" aria-label="Következő hét" icon={<FaChevronRight />} onClick={incrementWeek} />
       </HStack>
       <ZoomBar incrementScale={incrementScale} decrementScale={decrementScale} scale={scale} />
       <HStack flex={1} maxH={830} overflowY="auto" overflowX="hidden" w="full" mt={5} align="flex-start">

--- a/frontend/src/pages/events/components/event-calendar/ZoomBar.tsx
+++ b/frontend/src/pages/events/components/event-calendar/ZoomBar.tsx
@@ -9,10 +9,10 @@ interface ZoomBarProps {
 
 export function ZoomBar({ scale, incrementScale, decrementScale }: ZoomBarProps) {
   return (
-    <HStack justify="center">
-      <IconButton aria-label="Kicsinyítés" icon={<FaMinusCircle />} onClick={decrementScale} />
+    <HStack justify="center" mt={2}>
+      <IconButton colorScheme="brand" aria-label="Kicsinyítés" icon={<FaMinusCircle />} onClick={decrementScale} />
       <Text>{Math.round(scale * 100)}%</Text>
-      <IconButton aria-label="Nagyítás" icon={<FaPlusCircle />} onClick={incrementScale} />
+      <IconButton colorScheme="brand" aria-label="Nagyítás" icon={<FaPlusCircle />} onClick={incrementScale} />
     </HStack>
   )
 }

--- a/frontend/src/pages/events/eventCalendar.page.tsx
+++ b/frontend/src/pages/events/eventCalendar.page.tsx
@@ -23,7 +23,7 @@ function EventCalendarPage() {
   return (
     <CmschPage>
       <Helmet title="Naptár" />
-      <LinkButton href={AbsolutePaths.EVENTS} leftIcon={<FaArrowLeft />}>
+      <LinkButton colorScheme="brand" href={AbsolutePaths.EVENTS} leftIcon={<FaArrowLeft />}>
         Vissza a listához
       </LinkButton>
       <Box mb={10}>

--- a/frontend/src/pages/events/eventList.page.tsx
+++ b/frontend/src/pages/events/eventList.page.tsx
@@ -73,7 +73,9 @@ const EventListPage = () => {
     <CmschPage>
       <Helmet title={component.title ?? 'Események'} />
       <Box mb={5}>
-        <Heading mb={5}>{component.title}</Heading>
+        <Heading as="h1" mb={5}>
+          {component.title}
+        </Heading>
         {component.topMessage && <Markdown text={component.topMessage} />}
       </Box>
       <LinkButton colorScheme="brand" mb={5} leftIcon={<FaCalendar />} href={Paths.CALENDAR}>

--- a/frontend/src/pages/events/eventList.page.tsx
+++ b/frontend/src/pages/events/eventList.page.tsx
@@ -73,7 +73,7 @@ const EventListPage = () => {
     <CmschPage>
       <Helmet title={component.title ?? 'Események'} />
       <Box mb={5}>
-        <Heading as="h1" mb={5}>
+        <Heading as="h1" variant="main-title" mb={5}>
           {component.title}
         </Heading>
         {component.topMessage && <Markdown text={component.topMessage} />}

--- a/frontend/src/pages/events/eventList.page.tsx
+++ b/frontend/src/pages/events/eventList.page.tsx
@@ -76,7 +76,7 @@ const EventListPage = () => {
         <Heading mb={5}>{component.title}</Heading>
         {component.topMessage && <Markdown text={component.topMessage} />}
       </Box>
-      <LinkButton mb={5} leftIcon={<FaCalendar />} href={Paths.CALENDAR}>
+      <LinkButton colorScheme="brand" mb={5} leftIcon={<FaCalendar />} href={Paths.CALENDAR}>
         Megtekintés a naptárban
       </LinkButton>
       <Tabs size={tabsSize} isFitted={breakpoint !== 'base'} variant="soft-rounded" colorScheme="brand">

--- a/frontend/src/pages/extra/extra.page.tsx
+++ b/frontend/src/pages/extra/extra.page.tsx
@@ -12,7 +12,7 @@ import { useServiceContext } from '../../api/contexts/service/ServiceContext'
 import { l } from '../../util/language'
 import { PageStatus } from '../../common-components/PageStatus'
 
-interface ExtraPageProps {}
+interface ExtraPageProps { }
 
 const ExtraPage: FunctionComponent<ExtraPageProps> = () => {
   const params = useParams()
@@ -29,7 +29,9 @@ const ExtraPage: FunctionComponent<ExtraPageProps> = () => {
   return (
     <CmschPage>
       <Helmet title={data.title} />
-      <Heading as="h1">{data.title}</Heading>
+      <Heading as="h1" variant="main-title">
+        {data.title}
+      </Heading>
       <Markdown text={data.content} />
     </CmschPage>
   )

--- a/frontend/src/pages/extra/extra.page.tsx
+++ b/frontend/src/pages/extra/extra.page.tsx
@@ -29,7 +29,7 @@ const ExtraPage: FunctionComponent<ExtraPageProps> = () => {
   return (
     <CmschPage>
       <Helmet title={data.title} />
-      <Heading>{data.title}</Heading>
+      <Heading as="h1">{data.title}</Heading>
       <Markdown text={data.content} />
     </CmschPage>
   )

--- a/frontend/src/pages/form/form.page.tsx
+++ b/frontend/src/pages/form/form.page.tsx
@@ -67,7 +67,7 @@ const FormPage: FunctionComponent<FormPageProps> = () => {
     <CmschPage>
       <Helmet title={form?.name || 'Űrlap'} />
       <Box w="100%" mx="auto">
-        <Heading>{form?.name || 'Űrlap'}</Heading>
+        <Heading as="h1">{form?.name || 'Űrlap'}</Heading>
         <FormStatusBadge status={status} />
 
         {(submission?.rejectionMessage || message) && (

--- a/frontend/src/pages/form/form.page.tsx
+++ b/frontend/src/pages/form/form.page.tsx
@@ -22,7 +22,7 @@ import { FormFieldVariants, FormStatus, FormSubmitMessage, FormSubmitResult } fr
 import { AutoFormField } from './components/autoFormField'
 import { FormStatusBadge } from './components/formStatusBadge'
 
-interface FormPageProps {}
+interface FormPageProps { }
 
 const FormPage: FunctionComponent<FormPageProps> = () => {
   const toast = useToast()
@@ -67,7 +67,9 @@ const FormPage: FunctionComponent<FormPageProps> = () => {
     <CmschPage>
       <Helmet title={form?.name || 'Űrlap'} />
       <Box w="100%" mx="auto">
-        <Heading as="h1">{form?.name || 'Űrlap'}</Heading>
+        <Heading as="h1" variant="main-title">
+          {form?.name || 'Űrlap'}
+        </Heading>
         <FormStatusBadge status={status} />
 
         {(submission?.rejectionMessage || message) && (

--- a/frontend/src/pages/home/home.page.tsx
+++ b/frontend/src/pages/home/home.page.tsx
@@ -49,7 +49,7 @@ const HomePage = () => {
     <CmschPage>
       <Helmet />
       {homeConfig?.welcomeMessage && (
-        <Heading size="3xl" textAlign="center" marginTop={10} lineHeight="1.2">
+        <Heading as="h1" size="3xl" textAlign="center" marginTop={10} lineHeight="1.2">
           {homeConfig?.welcomeMessage.split('{}')[0] + ' '}
           {homeConfig?.welcomeMessage.split('{}').length > 1 && (
             <>

--- a/frontend/src/pages/home/home.page.tsx
+++ b/frontend/src/pages/home/home.page.tsx
@@ -49,7 +49,7 @@ const HomePage = () => {
     <CmschPage>
       <Helmet />
       {homeConfig?.welcomeMessage && (
-        <Heading as="h1" size="3xl" textAlign="center" marginTop={10} lineHeight="1.2">
+        <Heading variant="main-title" as="h1" size="3xl" textAlign="center" marginTop={10} lineHeight="1.2">
           {homeConfig?.welcomeMessage.split('{}')[0] + ' '}
           {homeConfig?.welcomeMessage.split('{}').length > 1 && (
             <>

--- a/frontend/src/pages/home/home.page.tsx
+++ b/frontend/src/pages/home/home.page.tsx
@@ -49,7 +49,7 @@ const HomePage = () => {
     <CmschPage>
       <Helmet />
       {homeConfig?.welcomeMessage && (
-        <Heading size="3xl" textAlign="center" marginTop={10}>
+        <Heading size="3xl" textAlign="center" marginTop={10} lineHeight="1.2">
           {homeConfig?.welcomeMessage.split('{}')[0] + ' '}
           {homeConfig?.welcomeMessage.split('{}').length > 1 && (
             <>
@@ -115,7 +115,9 @@ const HomePage = () => {
                 Nincs több esemény.
               </Text>
             )}
-            <LinkButton href={AbsolutePaths.EVENTS}>Részletek</LinkButton>
+            <LinkButton colorScheme="brand" href={AbsolutePaths.EVENTS}>
+              Részletek
+            </LinkButton>
           </VStack>
         </VStack>
       )}

--- a/frontend/src/pages/impressum/impressum.page.tsx
+++ b/frontend/src/pages/impressum/impressum.page.tsx
@@ -20,7 +20,7 @@ const ImpressumPage = () => {
   return (
     <CmschPage>
       <Helmet title={component.title} />
-      <Heading>{component.title}</Heading>
+      <Heading as="h1">{component.title}</Heading>
       <Markdown text={component.topMessage} />
       <Heading as="h2" size="lg" my="5" textAlign="center">
         Fejlesztők

--- a/frontend/src/pages/impressum/impressum.page.tsx
+++ b/frontend/src/pages/impressum/impressum.page.tsx
@@ -20,7 +20,9 @@ const ImpressumPage = () => {
   return (
     <CmschPage>
       <Helmet title={component.title} />
-      <Heading as="h1">{component.title}</Heading>
+      <Heading as="h1" variant="main-title">
+        {component.title}
+      </Heading>
       <Markdown text={component.topMessage} />
       <Heading as="h2" size="lg" my="5" textAlign="center">
         Fejlesztők

--- a/frontend/src/pages/leader-board/leaderBoard.page.tsx
+++ b/frontend/src/pages/leader-board/leaderBoard.page.tsx
@@ -47,7 +47,9 @@ const LeaderboardPage = () => {
       <Helmet title={title} />
       <Flex wrap="wrap" justify="space-between">
         <VStack>
-          <Heading as="h1">{title}</Heading>
+          <Heading as="h1" variant="main-title">
+            {title}
+          </Heading>
         </VStack>
         {component.leaderboardDetailsByCategoryEnabled && (
           <VStack>

--- a/frontend/src/pages/leader-board/leaderBoard.page.tsx
+++ b/frontend/src/pages/leader-board/leaderBoard.page.tsx
@@ -47,7 +47,7 @@ const LeaderboardPage = () => {
       <Helmet title={title} />
       <Flex wrap="wrap" justify="space-between">
         <VStack>
-          <Heading>{title}</Heading>
+          <Heading as="h1">{title}</Heading>
         </VStack>
         {component.leaderboardDetailsByCategoryEnabled && (
           <VStack>

--- a/frontend/src/pages/leader-board/leaderBoardCategory.page.tsx
+++ b/frontend/src/pages/leader-board/leaderBoardCategory.page.tsx
@@ -48,7 +48,7 @@ export default function LeaderboardCategoryPage() {
       <Helmet title={title} />
       <Flex wrap="wrap" justify="space-between">
         <VStack mb={5} align="flex-start">
-          <Heading>{title}</Heading>
+          <Heading as="h1">{title}</Heading>
           <Text>Kategóriák szerint</Text>
         </VStack>
         <VStack>

--- a/frontend/src/pages/leader-board/leaderBoardCategory.page.tsx
+++ b/frontend/src/pages/leader-board/leaderBoardCategory.page.tsx
@@ -48,7 +48,9 @@ export default function LeaderboardCategoryPage() {
       <Helmet title={title} />
       <Flex wrap="wrap" justify="space-between">
         <VStack mb={5} align="flex-start">
-          <Heading as="h1">{title}</Heading>
+          <Heading as="h1" variant="main-title">
+            {title}
+          </Heading>
           <Text>Kategóriák szerint</Text>
         </VStack>
         <VStack>

--- a/frontend/src/pages/map/map.page.tsx
+++ b/frontend/src/pages/map/map.page.tsx
@@ -16,7 +16,9 @@ export default function MapPage() {
   return (
     <CmschPage>
       <Helmet>Térkép</Helmet>
-      <Heading as="h1">Térkép</Heading>
+      <Heading as="h1" variant="main-title">
+        Térkép
+      </Heading>
       {component.topMessage && <Markdown text={component.topMessage} />}
       <Checkbox my={3} checked={showUserLocation} onChange={(e) => setShowUserLocation(e.target.checked)}>
         {l('location-show-own')}

--- a/frontend/src/pages/map/map.page.tsx
+++ b/frontend/src/pages/map/map.page.tsx
@@ -16,7 +16,7 @@ export default function MapPage() {
   return (
     <CmschPage>
       <Helmet>Térkép</Helmet>
-      <Heading>Térkép</Heading>
+      <Heading as="h1">Térkép</Heading>
       {component.topMessage && <Markdown text={component.topMessage} />}
       <Checkbox my={3} checked={showUserLocation} onChange={(e) => setShowUserLocation(e.target.checked)}>
         {l('location-show-own')}

--- a/frontend/src/pages/news/components/NewsList.tsx
+++ b/frontend/src/pages/news/components/NewsList.tsx
@@ -31,7 +31,7 @@ const NewsList = ({ newsList }: NewsListProps) => {
 
   return (
     <>
-      <Heading>{config?.components.news.title}</Heading>
+      <Heading as="h1">{config?.components.news.title}</Heading>
       <InputGroup my={10}>
         <InputLeftElement h="100%">
           <SearchIcon />

--- a/frontend/src/pages/news/components/NewsList.tsx
+++ b/frontend/src/pages/news/components/NewsList.tsx
@@ -31,7 +31,9 @@ const NewsList = ({ newsList }: NewsListProps) => {
 
   return (
     <>
-      <Heading as="h1">{config?.components.news.title}</Heading>
+      <Heading as="h1" variant="main-title">
+        {config?.components.news.title}
+      </Heading>
       <InputGroup my={10}>
         <InputLeftElement h="100%">
           <SearchIcon />

--- a/frontend/src/pages/qr-fight/qrLevels.page.tsx
+++ b/frontend/src/pages/qr-fight/qrLevels.page.tsx
@@ -26,7 +26,9 @@ export default function QrLevelsPage() {
     <CmschPage>
       <Helmet>{component.title}</Helmet>
       <Flex align="baseline" justifyContent="space-between" wrap="wrap">
-        <Heading mt={5}>{component.title}</Heading>
+        <Heading as="h1" mt={5}>
+          {component.title}
+        </Heading>
         <LinkButton my={5} colorScheme="brand" leftIcon={<FaQrcode />} href={`${AbsolutePaths.TOKEN}/scan`}>
           QR kód beolvasása
         </LinkButton>

--- a/frontend/src/pages/qr-fight/qrLevels.page.tsx
+++ b/frontend/src/pages/qr-fight/qrLevels.page.tsx
@@ -26,7 +26,7 @@ export default function QrLevelsPage() {
     <CmschPage>
       <Helmet>{component.title}</Helmet>
       <Flex align="baseline" justifyContent="space-between" wrap="wrap">
-        <Heading as="h1" mt={5}>
+        <Heading as="h1" variant="main-title" mt={5}>
           {component.title}
         </Heading>
         <LinkButton my={5} colorScheme="brand" leftIcon={<FaQrcode />} href={`${AbsolutePaths.TOKEN}/scan`}>

--- a/frontend/src/pages/race/components/RaceBoard.tsx
+++ b/frontend/src/pages/race/components/RaceBoard.tsx
@@ -26,7 +26,7 @@ const RaceBoard = ({ data, component, isError, isLoading }: Props) => {
   return (
     <CmschPage>
       <Helmet title={data.categoryName} />
-      <Heading as="h1" mb={3}>
+      <Heading as="h1" variant="main-title" mb={3}>
         {data.categoryName}
       </Heading>
       <Markdown text={data.description || component.defaultCategoryDescription} />

--- a/frontend/src/pages/race/components/RaceBoard.tsx
+++ b/frontend/src/pages/race/components/RaceBoard.tsx
@@ -26,7 +26,9 @@ const RaceBoard = ({ data, component, isError, isLoading }: Props) => {
   return (
     <CmschPage>
       <Helmet title={data.categoryName} />
-      <Heading mb={3}>{data.categoryName}</Heading>
+      <Heading as="h1" mb={3}>
+        {data.categoryName}
+      </Heading>
       <Markdown text={data.description || component.defaultCategoryDescription} />
       <Flex my={5} gap={5} flexWrap="wrap">
         <BoardStat label="Helyezésed" value={data.place || '-'} />

--- a/frontend/src/pages/riddle/riddleHistory.page.tsx
+++ b/frontend/src/pages/riddle/riddleHistory.page.tsx
@@ -59,7 +59,7 @@ const RiddleHistoryPage = () => {
       <Helmet title="Megoldott riddleök" />
       <CustomBreadcrumb items={breadcrumbItems} />
       <Stack direction={['column', 'row']} justify="space-between" align={['flex-start', 'center']}>
-        <Heading as="h1" my={5}>
+        <Heading as="h1" variant="main-title" my={5}>
           Megoldott riddleök
         </Heading>
         <Stack direction={['column']}>

--- a/frontend/src/pages/riddle/riddleHistory.page.tsx
+++ b/frontend/src/pages/riddle/riddleHistory.page.tsx
@@ -59,7 +59,9 @@ const RiddleHistoryPage = () => {
       <Helmet title="Megoldott riddleök" />
       <CustomBreadcrumb items={breadcrumbItems} />
       <Stack direction={['column', 'row']} justify="space-between" align={['flex-start', 'center']}>
-        <Heading my={5}>Megoldott riddleök</Heading>
+        <Heading as="h1" my={5}>
+          Megoldott riddleök
+        </Heading>
         <Stack direction={['column']}>
           <Select value={category} onChange={(e) => setCategory(e.target.value)} w="20rem">
             {query.data!!.map((c) => (

--- a/frontend/src/pages/riddle/riddleList.page.tsx
+++ b/frontend/src/pages/riddle/riddleList.page.tsx
@@ -38,7 +38,9 @@ const RiddleCategoryList = () => {
     <CmschPage>
       <Helmet title="Riddleök" />
       <Stack direction={['column', 'row']} justify="space-between" align={['flex-start', 'flex-end']}>
-        <Heading as="h1">Riddleök</Heading>
+        <Heading as="h1" variant="main-title">
+          Riddleök
+        </Heading>
         <Button colorScheme="brand" as={Link} to={AbsolutePaths.RIDDLE_HISTORY}>
           Megoldott riddleök
         </Button>

--- a/frontend/src/pages/riddle/riddleList.page.tsx
+++ b/frontend/src/pages/riddle/riddleList.page.tsx
@@ -38,7 +38,7 @@ const RiddleCategoryList = () => {
     <CmschPage>
       <Helmet title="Riddleök" />
       <Stack direction={['column', 'row']} justify="space-between" align={['flex-start', 'flex-end']}>
-        <Heading>Riddleök</Heading>
+        <Heading as="h1">Riddleök</Heading>
         <Button colorScheme="brand" as={Link} to={AbsolutePaths.RIDDLE_HISTORY}>
           Megoldott riddleök
         </Button>

--- a/frontend/src/pages/task/taskCategoryList.page.tsx
+++ b/frontend/src/pages/task/taskCategoryList.page.tsx
@@ -37,7 +37,9 @@ const TaskCategoryList = () => {
     <CmschPage loginRequired>
       <Helmet title={component.title} />
       {required}
-      <Heading as="h1">{component.regularTitle}</Heading>
+      <Heading as="h1" variant="main-title">
+        {component.regularTitle}
+      </Heading>
       {component.regularMessage && <Markdown text={component.regularMessage} />}
       {normalCategories.length > 0 ? (
         <VStack spacing={4} mt={5} align="stretch">

--- a/frontend/src/pages/task/taskCategoryList.page.tsx
+++ b/frontend/src/pages/task/taskCategoryList.page.tsx
@@ -37,7 +37,7 @@ const TaskCategoryList = () => {
     <CmschPage loginRequired>
       <Helmet title={component.title} />
       {required}
-      <Heading>{component.regularTitle}</Heading>
+      <Heading as="h1">{component.regularTitle}</Heading>
       {component.regularMessage && <Markdown text={component.regularMessage} />}
       {normalCategories.length > 0 ? (
         <VStack spacing={4} mt={5} align="stretch">

--- a/frontend/src/pages/teams/teamList.page.tsx
+++ b/frontend/src/pages/teams/teamList.page.tsx
@@ -24,7 +24,9 @@ export default function TeamListPage() {
   return (
     <CmschPage>
       <Helmet title={component.title} />
-      <Heading as="h1">{component.title}</Heading>
+      <Heading as="h1" variant="main-title">
+        {component.title}
+      </Heading>
       <SearchBar mt={5} {...searchArgs} />
       {searchArgs.filteredData?.map((team) => (
         <TeamListItem key={team.id} team={team} detailEnabled={component?.showTeamDetails} />

--- a/frontend/src/pages/teams/teamList.page.tsx
+++ b/frontend/src/pages/teams/teamList.page.tsx
@@ -24,9 +24,11 @@ export default function TeamListPage() {
   return (
     <CmschPage>
       <Helmet title={component.title} />
-      <Heading>{component.title}</Heading>
+      <Heading as="h1">{component.title}</Heading>
       <SearchBar mt={5} {...searchArgs} />
-      {searchArgs.filteredData?.map((team) => <TeamListItem key={team.id} team={team} detailEnabled={component?.showTeamDetails} />)}
+      {searchArgs.filteredData?.map((team) => (
+        <TeamListItem key={team.id} team={team} detailEnabled={component?.showTeamDetails} />
+      ))}
     </CmschPage>
   )
 }

--- a/frontend/src/pages/token/tokenList.page.tsx
+++ b/frontend/src/pages/token/tokenList.page.tsx
@@ -26,7 +26,9 @@ const TokenList = () => {
   return (
     <CmschPage loginRequired>
       <Helmet title={component.title || 'QR kódok'} />
-      <Heading as="h1">{component.title || 'QR kódok'}</Heading>
+      <Heading as="h1" variant="main-title">
+        {component.title || 'QR kódok'}
+      </Heading>
       <PresenceAlert acquired={data.collectedTokenCount} needed={data.minTokenToComplete} />
       {/* <Paragraph>
         A standoknál végzett aktív tevékenységért QR kódokat lehet beolvasni. Ha eleget összegyűjt, beválthatja egy tanköri jelenlétre.


### PR DESCRIPTION
- Transparent footer, if enabled on the backend
- Transparent navbar, if enabled on the backend
- Buttons in the event component now use the brand color
- page titles (with no user-defined text) promoted to h1. 
- headings no longer use the display font. Created a new Chakra Heading variant that uses the display font. Applied this variant to all h1 headings