### PR TITLE
Improve entity definition

### DIFF
--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/app/ComponentSettingEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/app/ComponentSettingEntity.kt
@@ -20,8 +20,7 @@ class ComponentSettingEntity(
     @Column(nullable = false)
     var property: String = "",
 
-    @Lob
-    @Column(nullable = false, name = "`value`")
+    @Column(nullable = false, name = "`value`", columnDefinition = "TEXT")
     var value: String = "",
 
 ) : Serializable

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/bmejegy/BmejegyRecordEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/bmejegy/BmejegyRecordEntity.kt
@@ -7,6 +7,7 @@ import hu.bme.sch.cmsch.dto.Edit
 import hu.bme.sch.cmsch.model.ManagedEntity
 import hu.bme.sch.cmsch.service.StaffPermissions
 import jakarta.persistence.*
+import org.hibernate.annotations.ColumnDefault
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.core.env.Environment
 
@@ -123,7 +124,8 @@ data class BmejegyRecordEntity(
     var matchedUserId: Int = 0,
 
     @Lob
-    @Column(nullable = false, columnDefinition = "CLOB default ''")
+    @ColumnDefault("''")
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT, order = 15, label = "Összes adat")
     @property:GenerateOverview(visible = false)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/bmejegy/BmejegyRecordEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/bmejegy/BmejegyRecordEntity.kt
@@ -123,7 +123,6 @@ data class BmejegyRecordEntity(
     @property:ImportFormat(ignore = false, columnId = 13, type = IMPORT_INT)
     var matchedUserId: Int = 0,
 
-    @Lob
     @ColumnDefault("''")
     @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/communities/CommunityEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/communities/CommunityEntity.kt
@@ -43,16 +43,14 @@ data class CommunityEntity(
     @property:ImportFormat(ignore = false, columnId = 1, type = IMPORT_BOOLEAN)
     var hideName: Boolean = false,
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class, FullDetails::class, Preview::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT, order = 3, label = "Rövid leírás")
     @property:GenerateOverview(visible = false)
     @property:ImportFormat(ignore = false, columnId = 2)
     var shortDescription: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class, FullDetails::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN, order = 4, label = "Teljes leírás")
     @property:GenerateOverview(visible = false)
@@ -141,8 +139,7 @@ data class CommunityEntity(
     @property:ImportFormat(ignore = false, columnId = 14)
     var application: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class, FullDetails::class ])
     @property:GenerateInput(order = 16, type = INPUT_TYPE_BLOCK_TEXT, label = "Képek URL-jei", enabled = true,
         note = "Az értékeket vesszővel elválasztva írd be (pl: alma, körte, barack)")
@@ -151,8 +148,7 @@ data class CommunityEntity(
     @get:JsonSerialize(using = StringToArraySerializer::class)
     var imageIds: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class, FullDetails::class ])
     @property:GenerateInput(order = 17, type = INPUT_TYPE_BLOCK_TEXT, label = "Videók URL-jei", enabled = true,
         note = "Az értékeket vesszővel elválasztva írd be (pl: alma, körte, barack)")
@@ -175,8 +171,7 @@ data class CommunityEntity(
     @property:ImportFormat(ignore = false, columnId = 18, type = IMPORT_INT)
     var resortId: Int = 0,
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class, FullDetails::class, Preview::class ])
     @property:GenerateInput(order = 20, type = INPUT_TYPE_BLOCK_TEXT, label = "Kulcsszavak", enabled = true)
     @property:GenerateOverview(visible = false)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/communities/OrganizationEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/communities/OrganizationEntity.kt
@@ -43,16 +43,14 @@ data class OrganizationEntity(
     @property:ImportFormat(ignore = false, columnId = 1, type = IMPORT_BOOLEAN)
     var hideName: Boolean = false,
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class, FullDetails::class, Preview::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT, order = 3, label = "Rövid leírás")
     @property:GenerateOverview(visible = false)
     @property:ImportFormat(ignore = false, columnId = 2)
     var shortDescription: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class, FullDetails::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN, order = 4, label = "Teljes leírás")
     @property:GenerateOverview(visible = false)
@@ -141,8 +139,7 @@ data class OrganizationEntity(
     @property:ImportFormat(ignore = false, columnId = 14)
     var application: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class, FullDetails::class ])
     @property:GenerateInput(order = 16, type = INPUT_TYPE_BLOCK_TEXT, label = "Képek URL-jei", enabled = true,
         note = "Az értékeket vesszővel elválasztva írd be (pl: alma, körte, barack)")
@@ -151,8 +148,7 @@ data class OrganizationEntity(
     @get:JsonSerialize(using = StringToArraySerializer::class)
     var imageIds: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class, FullDetails::class ])
     @property:GenerateInput(order = 17, type = INPUT_TYPE_BLOCK_TEXT, label = "Videók URL-jei", enabled = true,
         note = "Az értékeket vesszővel elválasztva írd be (pl: alma, körte, barack)")

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/conference/ConferenceEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/conference/ConferenceEntity.kt
@@ -34,9 +34,8 @@ data class ConferenceEntity(
     @property:ImportFormat(ignore = false, type = IMPORT_INT)
     var priority: Int = 0,
 
-    @Lob
     @field:JsonIgnore
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @property:GenerateInput(maxLength = 65535, order = 3, label = "Képek URL-jei",
         note = "A képek URL-jeit vesszővel elválasztva kell megadni.")
     @property:GenerateOverview(visible = false)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/conference/ConferencePresentationEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/conference/ConferencePresentationEntity.kt
@@ -77,8 +77,7 @@ data class ConferencePresentationEntity(
     @property:ImportFormat(ignore = false)
     var endTime: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @property:GenerateInput(order = 7, type = INPUT_TYPE_BLOCK_TEXT, label = "Leírás", enabled = true)
     @property:GenerateOverview(visible = false)
     @property:ImportFormat(ignore = false, type = IMPORT_LOB)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/debt/ProductEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/debt/ProductEntity.kt
@@ -53,8 +53,7 @@ data class ProductEntity(
     @property:ImportFormat(ignore = false, columnId = 2, type = IMPORT_ENUM, enumSource = ProductType::class)
     var type: ProductType = ProductType.OTHER,
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class, Preview::class, FullDetails::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT, order = 4, label = "Termék leírása")
     @property:GenerateOverview(visible = false)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/debt/ProductEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/debt/ProductEntity.kt
@@ -12,6 +12,7 @@ import org.hibernate.Hibernate
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.core.env.Environment
 import jakarta.persistence.*
+import org.hibernate.annotations.ColumnDefault
 
 enum class ProductType {
     MERCH,
@@ -80,7 +81,8 @@ data class ProductEntity(
     @property:ImportFormat(ignore = false, columnId = 5, type = IMPORT_BOOLEAN)
     var visible: Boolean = false,
 
-    @Column(nullable = false, columnDefinition = "varchar(255) default 'payments'")
+    @ColumnDefault("'payments'")
+    @Column(nullable = false, length = 255)
     @field:JsonView(value = [ Edit::class, Preview::class, FullDetails::class ])
     @property:GenerateInput(order = 8, label = "Material Ikon",
         note = "Innen kell kimásolni a nevét az ikonnak: https://fonts.google.com/icons")

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/debt/SoldProductEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/debt/SoldProductEntity.kt
@@ -11,6 +11,7 @@ import org.hibernate.Hibernate
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.core.env.Environment
 import jakarta.persistence.*
+import org.hibernate.annotations.ColumnDefault
 
 @Entity
 @Table(name="soldProducts")
@@ -123,7 +124,8 @@ data class SoldProductEntity(
     var log: String = "",
 
     @field:JsonView(value = [ Edit::class ])
-    @Column(nullable = false, columnDefinition = "varchar(255) default 'payments'")
+    @ColumnDefault("'payments'")
+    @Column(nullable = false, length = 255)
     @property:GenerateInput(order = 11, label = "Material Icon")
     @property:ImportFormat(ignore = false, columnId = 16)
     var materialIcon: String = "",

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/debt/SoldProductEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/debt/SoldProductEntity.kt
@@ -116,9 +116,8 @@ data class SoldProductEntity(
     @property:ImportFormat(ignore = false, columnId = 14)
     var finsihed: Boolean = false,
 
-    @Lob
     @field:JsonView(value = [ Edit::class ])
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT, order = 10, label = "Napló", enabled = false, ignore = true)
     @property:ImportFormat(ignore = false, columnId = 15)
     var log: String = "",

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/email/EmailTemplateEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/email/EmailTemplateEntity.kt
@@ -45,9 +45,8 @@ class EmailTemplateEntity(
     @property:ImportFormat
     var subject: String = "",
 
-    @Lob
     @field:JsonView(value = [ Edit::class ])
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @property:GenerateInput(order = 3, label = "Tartalom",
         note = "Ez az email tartalma, a változókat {{variable}} formátumban kell feltüntetni", type = INPUT_TYPE_BLOCK_TEXT)
     @property:GenerateOverview(visible = false)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/event/EventEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/event/EventEntity.kt
@@ -71,17 +71,15 @@ data class EventEntity(
     @property:ImportFormat(ignore = false, columnId = 5)
     var place: String = "",
 
-    @Lob
     @field:JsonView(value = [ Edit::class, Preview::class ])
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT, order = 8, label = "Rövid leírás")
     @property:GenerateOverview(visible = false)
     @property:ImportFormat(ignore = false, columnId = 6)
     var previewDescription: String = "",
 
-    @Lob
     @field:JsonView(value = [ Edit::class, FullDetails::class ])
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN, order = 9, label = "Hosszú leírás")
     @property:GenerateOverview(visible = false)
     @property:ImportFormat(ignore = false, columnId = 7)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/form/FormEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/form/FormEntity.kt
@@ -13,6 +13,7 @@ import org.hibernate.Hibernate
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.core.env.Environment
 import jakarta.persistence.*
+import org.hibernate.annotations.ColumnDefault
 
 @Entity
 @Table(name="forms")
@@ -164,7 +165,8 @@ data class FormEntity(
     var ownerIsGroup: Boolean = false,
 
     @field:JsonView(value = [ Edit::class ])
-    @Column(nullable = false, columnDefinition = "BOOLEAN default false")
+    @ColumnDefault("false")
+    @Column(nullable = false)
     @property:GenerateInput(type = INPUT_TYPE_SWITCH, order = 18, label = "Hírdetett",
         note = "Ha be van kapcsolva, akkor bizonyos oldalakon megjelenik mint kitöltendő form")
     @property:GenerateOverview(visible = false)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/form/FormEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/form/FormEntity.kt
@@ -50,9 +50,8 @@ data class FormEntity(
     @property:ImportFormat(ignore = false, columnId = 2)
     var menuName: String = "",
 
-    @Lob
     @field:JsonView(value = [ Edit::class, FullDetails::class ])
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @property:GenerateInput(type = INPUT_TYPE_FORM_EDITOR, order = 4, label = "Kitöltendő űrlap", defaultValue = "[]")
     @property:GenerateOverview(visible = false)
     @property:ImportFormat(ignore = false, columnId = 3, type = IMPORT_LOB)
@@ -78,16 +77,14 @@ data class FormEntity(
     @property:ImportFormat(ignore = false, columnId = 5, type = IMPORT_ENUM, enumSource = RoleType::class)
     var maxRole: RoleType = RoleType.SUPERUSER,
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN, order = 7, label = "Sikeres leadás utáni üzenet")
     @property:GenerateOverview(visible = false)
     @property:ImportFormat(ignore = false, columnId = 6, type = IMPORT_LOB)
     var submittedMessage: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN, order = 8, label = "Elfogadás utáni üzenet")
     @property:GenerateOverview(visible = false)
@@ -148,8 +145,7 @@ data class FormEntity(
     @property:ImportFormat(ignore = false, columnId = 14)
     var allowedGroups: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN, order = 16, label = "Csoport tagság miatt eltiltva üzenet")
     @property:GenerateOverview(visible = false)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/form/ResponseEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/form/ResponseEntity.kt
@@ -15,6 +15,7 @@ import hu.bme.sch.cmsch.model.ManagedEntity
 import hu.bme.sch.cmsch.service.StaffPermissions
 import jakarta.persistence.*
 import org.hibernate.Hibernate
+import org.hibernate.annotations.ColumnDefault
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.core.env.Environment
 
@@ -143,7 +144,8 @@ data class ResponseEntity(
     var detailsValidatedAt: Long = 0,
 
     @Lob
-    @Column(nullable = false, columnDefinition = "TEXT default ''")
+    @ColumnDefault("''")
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(order = 13, label = "Beadás történet", type = INPUT_TYPE_TASK_SUBMISSION_HISTORY)
     @property:GenerateOverview(visible = false)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/form/ResponseEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/form/ResponseEntity.kt
@@ -120,8 +120,7 @@ data class ResponseEntity(
     @property:ImportFormat(ignore = false, columnId = 11)
     var email: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class, Preview::class, FullDetails::class ])
     @property:GenerateInput(maxLength = 255, order = 10, label = "Kitöltés",
         note = "A kitöltés JSON formátumban", type = INPUT_TYPE_BLOCK_TEXT)
@@ -143,7 +142,6 @@ data class ResponseEntity(
     @property:ImportFormat(ignore = false, columnId = 14, type = IMPORT_LONG)
     var detailsValidatedAt: Long = 0,
 
-    @Lob
     @ColumnDefault("''")
     @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/location/LocationEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/location/LocationEntity.kt
@@ -9,6 +9,7 @@ import hu.bme.sch.cmsch.model.ManagedEntity
 import hu.bme.sch.cmsch.service.StaffPermissions
 import jakarta.persistence.*
 import org.hibernate.Hibernate
+import org.hibernate.annotations.ColumnDefault
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.core.env.Environment
 
@@ -110,14 +111,15 @@ data class LocationEntity(
     @property:GenerateOverview(visible = false)
     var markerShape: MapMarkerShape = MapMarkerShape.CIRCLE,
 
-    @Column(nullable = false, columnDefinition = "VARCHAR(16) default ''")
+    @ColumnDefault("''")
+    @Column(nullable = false, length = 16)
     @field:JsonView(value = [ Edit::class, FullDetails::class ])
     @property:GenerateInput(maxLength = 16, order = 18, label = "Szín")
     @property:GenerateOverview(visible = false)
     var markerColor: String = "#000000",
 
-    @Lob
-    @Column(nullable = false, columnDefinition = "VARCHAR(64) default ''")
+    @ColumnDefault("''")
+    @Column(nullable = false, length = 64)
     @field:JsonView(value = [ Edit::class, FullDetails::class ])
     @property:GenerateInput(order = 19, label = "Leírás", type = INPUT_TYPE_BLOCK_TEXT)
     @property:GenerateOverview(visible = false)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/location/WaypointEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/location/WaypointEntity.kt
@@ -9,6 +9,7 @@ import hu.bme.sch.cmsch.model.ManagedEntity
 import hu.bme.sch.cmsch.service.StaffPermissions
 import jakarta.persistence.*
 import org.hibernate.Hibernate
+import org.hibernate.annotations.ColumnDefault
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.core.env.Environment
 
@@ -24,7 +25,8 @@ data class WaypointEntity(
     @property:GenerateOverview(renderer = OVERVIEW_TYPE_ID, columnName = "ID", order = -1)
     override var id: Int = 0,
 
-    @Column(nullable = false, columnDefinition = "VARCHAR(64) default ''")
+    @ColumnDefault("''")
+    @Column(nullable = false, length = 64)
     @field:JsonView(value = [ Edit::class, FullDetails::class ])
     @property:GenerateInput(maxLength = 64, order = 1, label = "Kijelzett szöveg")
     @property:GenerateOverview(columnName = "Longitude", order = 1)
@@ -85,14 +87,15 @@ data class WaypointEntity(
     @property:GenerateOverview(visible = false)
     var markerShape: MapMarkerShape = MapMarkerShape.CIRCLE,
 
-    @Column(nullable = false, columnDefinition = "VARCHAR(16) default ''")
+    @ColumnDefault("''")
+    @Column(nullable = false, length = 16)
     @field:JsonView(value = [ Edit::class, FullDetails::class ])
     @property:GenerateInput(maxLength = 16, order = 11, label = "Szín")
     @property:GenerateOverview(visible = false)
     var markerColor: String = "#000000",
 
-    @Lob
-    @Column(nullable = false, columnDefinition = "VARCHAR(64) default ''")
+    @ColumnDefault("''")
+    @Column(nullable = false, length = 64)
     @field:JsonView(value = [ Edit::class, FullDetails::class ])
     @property:GenerateInput(order = 12, label = "Leírás", type = INPUT_TYPE_BLOCK_TEXT)
     @property:GenerateOverview(visible = false)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/news/NewsEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/news/NewsEntity.kt
@@ -43,18 +43,16 @@ data class NewsEntity(
     @property:ImportFormat(ignore = false, columnId = 1)
     var title: String = "",
 
-    @Lob
     @field:JsonView(value = [ Edit::class, Preview::class ])
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN, order = 3, label = "Rövid tartalom",
         note = "Ez a hír összesítésben megjelenő tartalma")
     @property:GenerateOverview(visible = false)
     @property:ImportFormat(ignore = false, columnId = 2)
     var briefContent: String = "",
 
-    @Lob
     @field:JsonView(value = [ Edit::class, FullDetails::class ])
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN, order = 3, label = "Tartalom",
             note = "Ez a hír teljes tartalma")
     @property:GenerateOverview(visible = false)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/proto/ProtoEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/proto/ProtoEntity.kt
@@ -34,9 +34,8 @@ data class ProtoEntity(
     @property:ImportFormat(ignore = false)
     var path: String = "",
 
-    @Lob
     @field:JsonView(value = [ Edit::class ])
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT, order = 2, label = "Válasz",
         note = "Ez a válasz jelenik meg a megadott útvonalon.")
     @property:GenerateOverview(visible = false)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/qrfight/QrLevelEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/qrfight/QrLevelEntity.kt
@@ -91,24 +91,21 @@ data class QrLevelEntity(
     @property:ImportFormat(ignore = false, columnId = 8)
     var dependsOn: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN, order = 10, label = "Leírás amég nem elérhető")
     @property:GenerateOverview(visible = false)
     @property:ImportFormat(ignore = false, columnId = 9, type = IMPORT_LOB)
     var hintBeforeEnabled: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN, order = 11, label = "Leírás ha elérhető")
     @property:GenerateOverview(visible = false)
     @property:ImportFormat(ignore = false, columnId = 10, type = IMPORT_LOB)
     var hintWhileOpen: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN, order = 12, label = "Leírás miután teljesítve lett")
     @property:GenerateOverview(visible = false)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/qrfight/QrTowerEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/qrfight/QrTowerEntity.kt
@@ -105,16 +105,14 @@ data class QrTowerEntity(
     @property:ImportFormat(ignore = false, columnId = 9)
     var ownerGroupName: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class, FullDetails::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN, order = 11, label = "Publikus leírás")
     @property:GenerateOverview(visible = false)
     @property:ImportFormat(ignore = false, columnId = 10, type = IMPORT_LOB)
     var publicMessage: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN, order = 12, label = "Leírás a tulajdonosoknak")
     @property:GenerateOverview(visible = false)
@@ -128,16 +126,14 @@ data class QrTowerEntity(
     @property:ImportFormat(ignore = false, columnId = 12, type = IMPORT_BOOLEAN)
     var recordTime: Boolean = false,
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT, order = 14, label = "Beolvasás log")
     @property:GenerateOverview(visible = false)
     @property:ImportFormat(ignore = false, columnId = 13, type = IMPORT_LOB)
     var history: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT, order = 15, label = "Birtoklás állása")
     @property:GenerateOverview(visible = false)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/qrfight/QrTowerEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/qrfight/QrTowerEntity.kt
@@ -12,6 +12,7 @@ import org.hibernate.Hibernate
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.core.env.Environment
 import jakarta.persistence.*
+import org.hibernate.annotations.ColumnDefault
 
 @Entity
 @Table(name="qrTowers")
@@ -160,7 +161,8 @@ data class QrTowerEntity(
     @property:ImportFormat(ignore = false, columnId = 16, type = IMPORT_INT)
     var holderFor: Int = 0,
 
-    @Column(nullable = false, columnDefinition = "BOOLEAN default false")
+    @ColumnDefault("false")
+    @Column(nullable = false)
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(type = INPUT_TYPE_SWITCH, order = 18, label = "Totem", note = "A totemek véglegesen kerülnek foglalásra, nem váltanak gazdát")
     @property:GenerateOverview(columnName = "Totem", centered = true, renderer = OVERVIEW_TYPE_BOOLEAN)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/race/RaceCategoryEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/race/RaceCategoryEntity.kt
@@ -40,9 +40,8 @@ data class RaceCategoryEntity(
     @property:ImportFormat(ignore = false, columnId = 1)
     var slug: String = "",
 
-    @Lob
     @field:JsonView(value = [ Edit::class, Preview::class ])
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN, order = 3, label = "Leírás",
         note = "Meg fog jelenni a kategória menüjének tetején")
     @property:GenerateOverview(visible = false)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/riddle/RiddleEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/riddle/RiddleEntity.kt
@@ -91,7 +91,6 @@ data class RiddleEntity(
     var firstSolver: String = "",
 
     @field:JsonView(value = [ Edit::class, Preview::class, FullDetails::class ])
-    @Lob
     @ColumnDefault("''")
     @Column(nullable = false, columnDefinition = "TEXT")
     @property:GenerateInput(order = 10, label = "Leírás",

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/riddle/RiddleEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/riddle/RiddleEntity.kt
@@ -12,6 +12,7 @@ import org.hibernate.Hibernate
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.core.env.Environment
 import jakarta.persistence.*
+import org.hibernate.annotations.ColumnDefault
 
 @Entity
 @Table(name="riddles")
@@ -91,7 +92,8 @@ data class RiddleEntity(
 
     @field:JsonView(value = [ Edit::class, Preview::class, FullDetails::class ])
     @Lob
-    @Column(nullable = false, columnDefinition = "TEXT default ''")
+    @ColumnDefault("''")
+    @Column(nullable = false, columnDefinition = "TEXT")
     @property:GenerateInput(order = 10, label = "Leírás",
         note = "Akkor jelenik meg ha nem üres",
         type = INPUT_TYPE_BLOCK_TEXT)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/staticpage/StaticPageEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/staticpage/StaticPageEntity.kt
@@ -43,8 +43,7 @@ data class StaticPageEntity(
     @property:ImportFormat(ignore = false, columnId = 1)
     var title: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class, FullDetails::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN, order = 3, label = "Az oldal tartalma")
     @property:GenerateOverview(visible = false)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/task/SubmittedTaskEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/task/SubmittedTaskEntity.kt
@@ -63,8 +63,7 @@ data class SubmittedTaskEntity(
     @Column(nullable = false)
     var categoryId: Int = 0,
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(order = 4, label = "Szöveges válasz (teljes)", enabled = false, ignore = true, type = INPUT_TYPE_BLOCK_TEXT)
     @property:GenerateOverview(visible = false)
@@ -106,7 +105,6 @@ data class SubmittedTaskEntity(
     @property:GenerateOverview(columnName = "Pont", order = 5, centered = true)
     var score: Int = 0,
 
-    @Lob
     @ColumnDefault("''")
     @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/task/SubmittedTaskEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/task/SubmittedTaskEntity.kt
@@ -13,6 +13,7 @@ import hu.bme.sch.cmsch.model.ManagedEntity
 import hu.bme.sch.cmsch.service.StaffPermissions
 import jakarta.persistence.*
 import org.hibernate.Hibernate
+import org.hibernate.annotations.ColumnDefault
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.core.env.Environment
 
@@ -106,7 +107,8 @@ data class SubmittedTaskEntity(
     var score: Int = 0,
 
     @Lob
-    @Column(nullable = false, columnDefinition = "TEXT default ''")
+    @ColumnDefault("''")
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(order = 11, label = "Beadás történet", type = INPUT_TYPE_TASK_SUBMISSION_HISTORY)
     @property:GenerateOverview(visible = false)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/task/TaskCategoryEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/task/TaskCategoryEntity.kt
@@ -12,6 +12,7 @@ import org.hibernate.Hibernate
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.core.env.Environment
 import jakarta.persistence.*
+import org.hibernate.annotations.ColumnDefault
 
 enum class TaskCategoryType {
     REGULAR,
@@ -68,7 +69,8 @@ data class TaskCategoryEntity(
     @property:ImportFormat(ignore = false, columnId = 4, type = IMPORT_ENUM, enumSource = TaskCategoryType::class)
     var type: TaskCategoryType = TaskCategoryType.REGULAR,
 
-    @Column(nullable = false, columnDefinition = "BOOLEAN default false")
+    @ColumnDefault("false")
+    @Column(nullable = false)
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(type = INPUT_TYPE_SWITCH, order = 6, label = "Hírdetett",
         note = "Külön kijelzésre kerülnek bizonyos helyeken az oldalon (pl. team komponens)")

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/task/TaskEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/task/TaskEntity.kt
@@ -53,16 +53,14 @@ data class TaskEntity(
     @property:ImportFormat(ignore = false, columnId = 1, type = IMPORT_INT)
     var categoryId: Int = 0,
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class, FullDetails::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN, order = 3, label = "Leírás")
     @property:GenerateOverview(visible = false)
     @property:ImportFormat(ignore = false, columnId = 2, type = IMPORT_LOB)
     var description: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class, FullDetails::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT, order = 4, label = "Beadandó formátum",
             note = "Ez a beadó mező mellett jelenik meg, külön a leírástól")
@@ -70,7 +68,6 @@ data class TaskEntity(
     @property:ImportFormat(ignore = false, columnId = 3, type = IMPORT_LOB)
     var expectedResultDescription: String = "",
 
-    @Lob
     @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN, order = 15, label = "Mintamegoldás",
@@ -97,8 +94,7 @@ data class TaskEntity(
     @property:ImportFormat(ignore = false, columnId = 5, type = IMPORT_ENUM, enumSource = TaskFormat::class)
     var format: TaskFormat = TaskFormat.NONE,
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class, FullDetails::class ])
     @property:GenerateInput(type = INPUT_TYPE_BLOCK_TEXT, order = 7, label = "Formátum leírása",
         note = "Ha a formátum FORM akkor ide kell beírni a form jsonját. " +

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/token/TokenEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/token/TokenEntity.kt
@@ -97,7 +97,6 @@ data class TokenEntity(
     var displayIconUrl: String = "",
 
     @field:JsonView(value = [ Edit::class ])
-    @Lob
     @ColumnDefault("''")
     @Column(nullable = false, columnDefinition = "TEXT")
     @property:GenerateInput(order = 10, label = "Kijelzett szöveg",

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/token/TokenEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/token/TokenEntity.kt
@@ -12,6 +12,7 @@ import org.hibernate.Hibernate
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.core.env.Environment
 import jakarta.persistence.*
+import org.hibernate.annotations.ColumnDefault
 
 @Entity
 @Table(name="tokens")
@@ -78,7 +79,8 @@ data class TokenEntity(
     var action: String = "",
 
     @field:JsonView(value = [ Edit::class ])
-    @Column(nullable = false, columnDefinition = "BOOLEAN default FALSE")
+    @ColumnDefault("false")
+    @Column(nullable = false)
     @property:GenerateInput(type = INPUT_TYPE_SWITCH, order = 8, label = "Aktív cél",
         note = "Csak akkor ha a QR Fight komponens is be van töltve")
     @property:GenerateOverview(visible = false)
@@ -86,7 +88,8 @@ data class TokenEntity(
     var activeTarget: Boolean = false,
 
     @field:JsonView(value = [ Edit::class ])
-    @Column(nullable = false, columnDefinition = "VARCHAR(255) default ''")
+    @ColumnDefault("''")
+    @Column(nullable = false, length = 255)
     @property:GenerateInput(maxLength = 255, order = 9, label = "Kijelzett kép URL-je",
         note = "Ha nem üres, megjelenik beolvasás után")
     @property:GenerateOverview(visible = false)
@@ -95,7 +98,8 @@ data class TokenEntity(
 
     @field:JsonView(value = [ Edit::class ])
     @Lob
-    @Column(nullable = false, columnDefinition = "TEXT default ''")
+    @ColumnDefault("''")
+    @Column(nullable = false, columnDefinition = "TEXT")
     @property:GenerateInput(order = 10, label = "Kijelzett szöveg",
         note = "Ha nem üres, megjelenik beolvasás után", type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN)
     @property:GenerateOverview(visible = false)
@@ -103,14 +107,16 @@ data class TokenEntity(
     var displayDescription: String = "",
 
     @field:JsonView(value = [ Edit::class, Preview::class, FullDetails::class ])
-    @Column(nullable = true, columnDefinition = "BIGINT DEFAULT NULL")
+    @ColumnDefault("null")
+    @Column(nullable = true, columnDefinition = "BIGINT")
     @property:GenerateInput(type = INPUT_TYPE_DATE, order = 11, label = "Scannelhető innentől")
     @property:GenerateOverview(columnName = "Ettől", order = 5, renderer = OVERVIEW_TYPE_DATE)
     @property:ImportFormat(ignore = false, type = IMPORT_LONG)
     var availableFrom: Long? = null,
 
     @field:JsonView(value = [ Edit::class, Preview::class, FullDetails::class ])
-    @Column(nullable = true, columnDefinition = "BIGINT DEFAULT NULL")
+    @ColumnDefault("null")
+    @Column(nullable = true, columnDefinition = "BIGINT")
     @property:GenerateInput(type = INPUT_TYPE_DATE, order = 12, label = "Scannelhető eddig")
     @property:GenerateOverview(columnName = "Eddig", order = 6, renderer = OVERVIEW_TYPE_DATE)
     @property:ImportFormat(ignore = false, type = IMPORT_LONG)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/model/GroupEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/model/GroupEntity.kt
@@ -113,16 +113,14 @@ data class GroupEntity(
     @property:ImportFormat(ignore = false, columnId = 9, type = IMPORT_BOOLEAN)
     var manuallyCreated: Boolean = false,
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(order = 17, label = "Leírás", type = INPUT_TYPE_BLOCK_TEXT)
     @property:GenerateOverview(visible = false)
     @property:ImportFormat(ignore = false, columnId = 10, type = IMPORT_LOB)
     var description: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(order = 18, label = "Egyedi szöveg a profilhoz", type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN)
     @property:GenerateOverview(visible = false)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/model/UserDetailsByInternalIdMappingEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/model/UserDetailsByInternalIdMappingEntity.kt
@@ -72,9 +72,8 @@ data class UserDetailsByInternalIdMappingEntity(
     @property:ImportFormat(ignore = false, columnId = 4, type = IMPORT_ENUM, enumSource = MajorType::class, defaultValue = "UNKNOWN")
     var major: MajorType? = null,
 
-    @Lob
     @field:JsonView(value = [ Edit::class ])
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @property:GenerateInput(order = 7, label = "Jogosultságok", enabled = true, type = INPUT_TYPE_PERMISSIONS)
     @property:ImportFormat(ignore = false, columnId = 5)
     var permissions: String? = null,
@@ -85,7 +84,7 @@ data class UserDetailsByInternalIdMappingEntity(
     @property:ImportFormat(ignore = false, columnId = 6)
     var profilePicture: String? = null,
 
-    @Lob
+    @Column(columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(order = 9, label = "Egyedi szöveg a profilhoz", type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN)
     @property:GenerateOverview(visible = false)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/model/UserEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/model/UserEntity.kt
@@ -158,9 +158,8 @@ data class UserEntity(
     @property:ImportFormat(ignore = false, columnId = 8, type = IMPORT_ENUM, enumSource = MajorType::class, defaultValue = "UNKNOWN")
     var major: MajorType = MajorType.UNKNOWN,
 
-    @Lob
     @field:JsonView(value = [ Edit::class ])
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @property:GenerateInput(order = 16, label = "Jogosultságok", enabled = true, type = INPUT_TYPE_PERMISSIONS, maxLength = 20000)
     @property:ImportFormat(ignore = false, columnId = 9)
     var permissions: String = "",
@@ -185,8 +184,7 @@ data class UserEntity(
     @property:ImportFormat(ignore = false, columnId = 12)
     var unitScopes: String = "",
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(order = 15, label = "Egyedi szöveg a profilhoz", type = INPUT_TYPE_BLOCK_TEXT_MARKDOWN)
     @property:GenerateOverview(visible = false)
@@ -200,8 +198,7 @@ data class UserEntity(
     @property:ImportFormat(ignore = false, columnId = 14, type = IMPORT_BOOLEAN)
     var detailsImported: Boolean = false,
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     @field:JsonView(value = [ Edit::class ])
     @property:GenerateInput(order = 16, label = "Konfigurációs beállítások", type = INPUT_TYPE_BLOCK_TEXT)
     @property:GenerateOverview(visible = false)


### PR DESCRIPTION
There are no invalid sql statement errors at startup anymore.

With Postgres, this is the DDL diff (in the previous version the 'create table' for bmejegy failed)

> create table bmejegy_records
> (
>     id              integer               not null
>         primary key,
>     date            varchar(255)          not null,
>     email           varchar(255)          not null,
>     faculty         varchar(255)          not null,
>     full_name       varchar(255)          not null,
>     id_id           varchar(255)          not null,
>     item            varchar(255)          not null,
>     item_id         varchar(255)          not null,
>     matched_user_id integer               not null,
>     order_key       varchar(255)          not null,
>     photo_id        varchar(255)          not null,
>     qr_code         varchar(255)          not null,
>     raw_data        text default ''::text not null,
>     registered      bigint                not null,
>     status          varchar(255)          not null,
>     total           varchar(255)          not null
> );
>
> alter table bmejegy_records
>     owner to psqluser;
>