### PR TITLE
Refresh navbar cache after extra-menu modification

### DIFF
--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/app/ExtraMenuController.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/app/ExtraMenuController.kt
@@ -17,6 +17,7 @@ class ExtraMenuController(
     repo: ExtraMenuRepository,
     importService: ImportService,
     adminMenuService: AdminMenuService,
+    private val menuService: MenuService,
     component: ApplicationComponent,
     auditLog: AuditLogService,
     objectMapper: ObjectMapper,
@@ -53,4 +54,9 @@ class ExtraMenuController(
     adminMenuPriority = 4,
 
     searchSettings = calculateSearchSettings<ExtraMenuEntity>(false)
-)
+) {
+    override fun onImported() { menuService.regenerateMenuCache() }
+    override fun onEntityChanged(entity: ExtraMenuEntity) { menuService.regenerateMenuCache() }
+    override fun onEntitiesPurged() { menuService.regenerateMenuCache() }
+    override fun onEntityDeleted(entity: ExtraMenuEntity) { menuService.regenerateMenuCache() }
+}

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/app/MenuService.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/app/MenuService.kt
@@ -47,13 +47,12 @@ open class MenuService(
     }
 
     @EventListener
+    @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)
     fun onStarted(event: ContextRefreshedEvent) {
-        log.info("Refreshing menu from database")
-        RoleType.entries.forEach { role ->
-            regenerateMenuCache(role)
-        }
+        regenerateMenuCache()
     }
 
+    @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)
     fun getMenusForRole(role: RoleType): List<MenuSettingItem> {
         val possibleMenus = mutableListOf<MenuSettingItem>()
 
@@ -146,6 +145,14 @@ open class MenuService(
         }
         menuRepository.saveAll(menusToStore)
         regenerateMenuCache(role)
+    }
+
+    @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)
+    fun regenerateMenuCache() {
+        log.info("Refreshing menu from database")
+        RoleType.entries.forEach { role ->
+            regenerateMenuCache(role)
+        }
     }
 
     @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)


### PR DESCRIPTION
The app navbar is now refreshed when an extra-menu is added, removed or edited

Fixes #732 