### PR TITLE
feat: add secure cookie based auth

### DIFF
--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/config/WebMvcConfig.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/config/WebMvcConfig.kt
@@ -28,6 +28,7 @@ class WebMvcConfig(
         arrayOf("/api/**", "/manifest/**", "/cdn/**").forEach {
             registry.addMapping(it)
                 .allowedOrigins(productionUrl)
+                .allowCredentials(true)
                 .allowedOriginPatterns(*allowedOrigins.toTypedArray())
                 .allowedMethods(*HttpMethod.values().map(HttpMethod::name).toTypedArray())
         }

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/service/JwtTokenProvider.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/service/JwtTokenProvider.kt
@@ -99,12 +99,8 @@ class JwtTokenProvider(
     private fun parseToken(token: String) = parser.parseSignedClaims(token).payload
 
     fun resolveToken(req: HttpServletRequest): String? {
-        val bearerToken = req.getHeader("Authorization")
-        return if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
-            bearerToken.substring(7, bearerToken.length)
-        } else {
-            null
-        }
+        val jwtCookie = req.cookies?.find { it.name == "jwt" }?.value
+        return jwtCookie
     }
 
     fun validateToken(token: String): Boolean {

--- a/frontend/src/api/contexts/auth/AuthContext.tsx
+++ b/frontend/src/api/contexts/auth/AuthContext.tsx
@@ -1,27 +1,15 @@
-import Cookies from 'js-cookie'
-import { createContext, PropsWithChildren, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { initAxios, queryClient } from '../../../util/configs/api.config'
-import { CookieKeys } from '../../../util/configs/cookies.config'
+import { createContext, PropsWithChildren } from 'react'
 import { API_BASE_URL } from '../../../util/configs/environment.config'
-import { AbsolutePaths } from '../../../util/paths'
 import { ProfileView } from '../../../util/views/profile.view'
 import { useProfileQuery } from '../../hooks/profile/useProfileQuery'
-import { useTokenRefresh } from '../../hooks/useTokenRefresh'
-import { QueryKeys } from '../../hooks/queryKeys'
-import { useConfigContext } from '../config/ConfigContext.tsx'
-import { unsubscribeFromNotifications } from '../../../util/configs/firebase.config.ts'
 
 export type AuthContextType = {
   isLoggedIn: boolean
   profile: ProfileView | undefined
   profileLoading: boolean
   profileError: Error | null
-  onLoginSuccess: (response: { jwt: string }) => void
-  onLoginFailure: (response: any) => void
   onLogout: () => void
   refetch: () => void
-  refreshToken: (onSuccess: (token: string) => void) => void
 }
 
 export const AuthContext = createContext<AuthContextType>({
@@ -29,61 +17,16 @@ export const AuthContext = createContext<AuthContextType>({
   profile: undefined,
   profileLoading: false,
   profileError: null,
-  onLoginSuccess: () => {},
-  onLoginFailure: () => {},
   onLogout: () => {},
-  refetch: () => {},
-  refreshToken: (_) => {}
+  refetch: () => {}
 })
 
 export const AuthProvider = ({ children }: PropsWithChildren) => {
-  const navigate = useNavigate()
-  const config = useConfigContext()
-
-  const onLoginFailure = () => {
-    Cookies.remove(CookieKeys.JWT_TOKEN)
-    Cookies.remove(CookieKeys.SESSION_ID)
-    queryClient.invalidateQueries(QueryKeys.USER, { refetchInactive: false })
-    console.error('Login failure')
-    navigate('/')
-  }
-
-  const onLoginSuccess = async ({ jwt }: { jwt: string }) => {
-    Cookies.set(CookieKeys.JWT_TOKEN, jwt, { expires: 2 })
-    try {
-      await queryClient.invalidateQueries(QueryKeys.USER, { refetchInactive: true }, { throwOnError: true })
-      await queryClient.invalidateQueries(QueryKeys.CONFIG, { refetchInactive: true }, { throwOnError: true })
-      navigate(AbsolutePaths.PROFILE)
-    } catch (err) {
-      console.error('Login failure')
-    }
-  }
-
   const onLogout = async () => {
-    if (config.components.pushnotification?.notificationsEnabled) {
-      await unsubscribeFromNotifications()
-    }
-    Cookies.remove(CookieKeys.JWT_TOKEN)
-    Cookies.remove(CookieKeys.SESSION_ID)
     window.location.href = `${API_BASE_URL}/control/logout`
   }
 
   const { isLoading: profileLoading, data: profile, error: profileError, refetch } = useProfileQuery()
-  const { refresh } = useTokenRefresh(onLoginFailure)
-
-  useEffect(() => {
-    if (Cookies.get(CookieKeys.JWT_TOKEN)) {
-      refresh((token) => Cookies.set(CookieKeys.JWT_TOKEN, token))
-    }
-  }, [])
-
-  const refreshToken = (onSuccess: (token: string) => void) => {
-    refresh((token) => {
-      Cookies.set(CookieKeys.JWT_TOKEN, token)
-      initAxios()
-      onSuccess(token)
-    })
-  }
 
   return (
     <AuthContext.Provider
@@ -92,11 +35,8 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
         profileLoading,
         profile,
         profileError,
-        onLoginSuccess,
-        onLoginFailure,
         onLogout,
-        refetch,
-        refreshToken
+        refetch
       }}
     >
       {children}

--- a/frontend/src/api/hooks/profile/useProfileQuery.ts
+++ b/frontend/src/api/hooks/profile/useProfileQuery.ts
@@ -4,13 +4,9 @@ import { ProfileView } from '../../../util/views/profile.view'
 import { QueryKeys } from '../queryKeys'
 import { ApiPaths } from '../../../util/paths'
 
-export const useProfileQuery = (onLoginFailure?: (err: any) => void) => {
-  return useQuery<ProfileView, Error>(
-    QueryKeys.USER,
-    async () => {
-      const response = await axios.get<ProfileView>(ApiPaths.PROFILE)
-      return response.data
-    },
-    { onError: onLoginFailure }
-  )
+export const useProfileQuery = () => {
+  return useQuery<ProfileView, Error>(QueryKeys.USER, async () => {
+    const response = await axios.get<ProfileView>(ApiPaths.PROFILE)
+    return response.data
+  })
 }

--- a/frontend/src/pages/form/form.page.tsx
+++ b/frontend/src/pages/form/form.page.tsx
@@ -1,5 +1,4 @@
 import { Box, Button, Divider, FormControl, FormLabel, Heading, useToast } from '@chakra-ui/react'
-import Cookies from 'js-cookie'
 import { FunctionComponent, useEffect } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { FormProvider, useForm } from 'react-hook-form'
@@ -14,7 +13,6 @@ import { ComponentUnavailable } from '../../common-components/ComponentUnavailab
 import { CmschPage } from '../../common-components/layout/CmschPage'
 import Markdown from '../../common-components/Markdown'
 import { PageStatus } from '../../common-components/PageStatus'
-import { CookieKeys } from '../../util/configs/cookies.config'
 import { isCheckbox, isGridField } from '../../util/core-functions.util'
 import { l } from '../../util/language'
 import { AbsolutePaths } from '../../util/paths'
@@ -31,7 +29,7 @@ const FormPage: FunctionComponent<FormPageProps> = () => {
   const formMethods = useForm()
   const { submit, submitLoading, result } = useFormSubmit(params.slug || '')
   const { data, isLoading, isError, refetch } = useFormPage(params.slug || '')
-  const { refresh } = useTokenRefresh()
+  const tokenRefresh = useTokenRefresh()
   const { sendMessage } = useServiceContext()
 
   useEffect(() => {
@@ -39,8 +37,8 @@ const FormPage: FunctionComponent<FormPageProps> = () => {
       const success = result === FormSubmitResult.OK || result === FormSubmitResult.OK_RELOG_REQUIRED
       toast({ title: FormSubmitMessage[result as FormSubmitResult], status: success ? 'success' : 'error' })
     }
-    if (result === FormSubmitResult.OK_RELOG_REQUIRED && Cookies.get(CookieKeys.JWT_TOKEN)) {
-      refresh((token) => Cookies.set(CookieKeys.JWT_TOKEN, token))
+    if (result === FormSubmitResult.OK_RELOG_REQUIRED) {
+      tokenRefresh.mutate()
     }
     refetch()
   }, [result])

--- a/frontend/src/pages/index/index.page.tsx
+++ b/frontend/src/pages/index/index.page.tsx
@@ -1,33 +1,16 @@
-import { useToast } from '@chakra-ui/react'
 import { useEffect } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
 import { useAuthContext } from '../../api/contexts/auth/useAuthContext'
 import { useConfigContext } from '../../api/contexts/config/ConfigContext'
-import { l } from '../../util/language'
 
 const IndexPage = () => {
   const location = useLocation()
-  const toast = useToast()
-  const { onLogout, onLoginSuccess } = useAuthContext()
+  const { onLogout } = useAuthContext()
   const config = useConfigContext()
 
   useEffect(() => {
     if (location.pathname === '/logout') {
       onLogout()
-    }
-
-    const searchParams = new URLSearchParams(location.search)
-    if (searchParams.get('logged-out') == 'true') {
-      toast({
-        title: l('logout-title'),
-        description: l('logout-description'),
-        status: 'success',
-        duration: 5000,
-        isClosable: true
-      })
-    }
-    if (searchParams.has('jwt')) {
-      onLoginSuccess({ jwt: searchParams.get('jwt')!! })
     }
   }, [location])
 

--- a/frontend/src/pages/teams/createTeam.page.tsx
+++ b/frontend/src/pages/teams/createTeam.page.tsx
@@ -1,22 +1,24 @@
-import { useAuthContext } from '../../api/contexts/auth/useAuthContext'
-import { CmschPage } from '../../common-components/layout/CmschPage'
+import { Button, FormControl, FormLabel, Heading, HStack, Input, Text, VStack } from '@chakra-ui/react'
+import { useState } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { useForm } from 'react-hook-form'
-import { CreateTeamDto, TeamResponseMessages, TeamResponses } from '../../util/views/team.view'
-import { Button, FormControl, FormLabel, Heading, HStack, Input, Text, VStack } from '@chakra-ui/react'
-import { useTeamCreate } from '../../api/hooks/team/actions/useTeamCreate'
 import { Navigate, useNavigate } from 'react-router-dom'
-import { AbsolutePaths } from '../../util/paths'
-import { useState } from 'react'
 import { useConfigContext } from '../../api/contexts/config/ConfigContext'
-import Markdown from '../../common-components/Markdown'
+import { useTeamCreate } from '../../api/hooks/team/actions/useTeamCreate'
+import { useTokenRefresh } from '../../api/hooks/useTokenRefresh.ts'
 import { ComponentUnavailable } from '../../common-components/ComponentUnavailable'
+import { CmschPage } from '../../common-components/layout/CmschPage'
+import Markdown from '../../common-components/Markdown'
+import { AbsolutePaths } from '../../util/paths.ts'
+import { CreateTeamDto, TeamResponseMessages, TeamResponses } from '../../util/views/team.view'
 
 export default function CreateTeamPage() {
   const navigate = useNavigate()
   const [requestError, setRequestError] = useState<string>()
-  const { refreshToken } = useAuthContext()
   const config = useConfigContext()
+  const tokenRefresh = useTokenRefresh(() => {
+    navigate(AbsolutePaths.MY_TEAM)
+  })
   const {
     register,
     handleSubmit,
@@ -25,7 +27,7 @@ export default function CreateTeamPage() {
 
   const { createTeamLoading, createTeamError, createTeam } = useTeamCreate((response) => {
     if (response === TeamResponses.OK) {
-      refreshToken(() => navigate(AbsolutePaths.MY_TEAM))
+      tokenRefresh.mutate()
     } else {
       setRequestError(TeamResponseMessages[response as TeamResponses])
     }

--- a/frontend/src/pages/teams/editMyTeam.page.tsx
+++ b/frontend/src/pages/teams/editMyTeam.page.tsx
@@ -1,24 +1,26 @@
-import { useAuthContext } from '../../api/contexts/auth/useAuthContext'
-import { CmschPage } from '../../common-components/layout/CmschPage'
+import { Alert, AlertIcon, Box, Button, FormControl, FormLabel, Heading, Input, Text, VStack } from '@chakra-ui/react'
+import { useState } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { useForm } from 'react-hook-form'
-import { TeamEditDto, TeamResponseMessages, TeamResponses } from '../../util/views/team.view'
-import { Alert, AlertIcon, Box, Button, FormControl, FormLabel, Heading, Input, Text, VStack } from '@chakra-ui/react'
 import { Navigate, useNavigate } from 'react-router-dom'
-import { AbsolutePaths } from '../../util/paths'
-import { useState } from 'react'
 import { useConfigContext } from '../../api/contexts/config/ConfigContext'
-import Markdown from '../../common-components/Markdown'
-import { ComponentUnavailable } from '../../common-components/ComponentUnavailable'
 import { useTeamEdit } from '../../api/hooks/team/actions/useTeamEdit'
-import { FilePicker } from '../task/components/FilePicker'
+import { useTokenRefresh } from '../../api/hooks/useTokenRefresh.ts'
+import { ComponentUnavailable } from '../../common-components/ComponentUnavailable'
+import { CmschPage } from '../../common-components/layout/CmschPage'
+import Markdown from '../../common-components/Markdown'
+import { AbsolutePaths } from '../../util/paths.ts'
 import { RoleType } from '../../util/views/profile.view'
+import { TeamEditDto, TeamResponseMessages, TeamResponses } from '../../util/views/team.view'
+import { FilePicker } from '../task/components/FilePicker'
 
 export default function EditMyTeamPage() {
   const navigate = useNavigate()
   const [requestError, setRequestError] = useState<string>()
   const [logo, setLogo] = useState<File>()
-  const { refreshToken } = useAuthContext()
+  const tokenRefresh = useTokenRefresh(() => {
+    navigate(AbsolutePaths.MY_TEAM)
+  })
   const config = useConfigContext()
   const {
     register,
@@ -28,7 +30,7 @@ export default function EditMyTeamPage() {
 
   const { teamEditLoading, teamEditError, teamEdit } = useTeamEdit((response) => {
     if (response === TeamResponses.OK) {
-      refreshToken(() => navigate(AbsolutePaths.MY_TEAM))
+      tokenRefresh.mutate()
     } else {
       setRequestError(TeamResponseMessages[response as TeamResponses])
     }

--- a/frontend/src/util/configs/api.config.ts
+++ b/frontend/src/util/configs/api.config.ts
@@ -1,18 +1,10 @@
 import axios from 'axios'
-import Cookies from 'js-cookie'
 import { QueryClient } from 'react-query'
-import { CookieKeys } from './cookies.config'
 import { API_BASE_URL } from './environment.config'
 
 export const initAxios = () => {
   axios.defaults.baseURL = API_BASE_URL
-  axios.interceptors.request.use((config) => {
-    const token = Cookies.get(CookieKeys.JWT_TOKEN)
-    if (token && config.headers) {
-      config.headers['Authorization'] = `Bearer ${token}`
-    }
-    return config
-  })
+  axios.defaults.withCredentials = true
 }
 
 export const queryClient = new QueryClient({


### PR DESCRIPTION
With this PR approved, the backend will start to set cookies for the domain from the site url, making cookies HTTP only and Secure, removing the need to manually get the JWT from the query param and state manage from there.
I made sure to handle the refresh mechanism for Create & Edit team flows as well as form submission.
Logout works as well by setting the cookie to null.