### PR TITLE
Focus input after submitting riddle

### DIFF
--- a/frontend/src/pages/riddle/riddle.page.tsx
+++ b/frontend/src/pages/riddle/riddle.page.tsx
@@ -78,6 +78,7 @@ const RiddlePage = () => {
                 duration: 5000,
                 isClosable: true
               }) || null
+            solutionInput.current?.focus()
           }
           if (result.status === RiddleSubmissionStatus.SUBMITTER_BANNED) {
             if (toastIdRef.current) {


### PR DESCRIPTION
After the user submits the riddle, and it was not correct, the ref to the solutionInput gets focused.

After using the riddles a few times, I noticed that I always had to click back to the input field, after submitting the riddle, even when I didn't press the Submit button, but pressed Enter. This should fix that.