### PR TITLE
Fix Mobile background on smaller screens

### DIFF
--- a/frontend/src/common-components/layout/AppBackground.tsx
+++ b/frontend/src/common-components/layout/AppBackground.tsx
@@ -6,18 +6,16 @@ export const AppBackground: FC<PropsWithChildren> = ({ children }) => {
   const config = useConfigContext()
   const textColor = useColorModeValue(config.components.style.lightTextColor, config.components.style.darkTextColor)
   const background = useColorModeValue(config.components.style.lightBackgroundColor, config.components.style.darkBackgroundColor)
-  let backgroundImageData: [string, string] = [
+
+  const backgroundImage = useColorModeValue(
     `url(${config.components.style.lightBackgroundUrl})`,
     `url(${config.components.style.darkBackgroundUrl})`
-  ];
+  )
 
-  if (window.innerWidth <= 768)
-    backgroundImageData = [
-      `url(${config.components.style.lightMobileBackgroundUrl})`,
-      `url(${config.components.style.darkMobileBackgroundUrl})`
-    ];
-
-  const backgroundImage = useColorModeValue(...backgroundImageData)
+  const mobileBackgroundImage = useColorModeValue(
+    `url(${config.components.style.lightMobileBackgroundUrl})`,
+    `url(${config.components.style.darkMobileBackgroundUrl})`
+  )
 
   return (
     <>
@@ -28,7 +26,7 @@ export const AppBackground: FC<PropsWithChildren> = ({ children }) => {
         width="100vw"
         bg={background}
         color={textColor}
-        bgImage={backgroundImage}
+        bgImage={{ base: mobileBackgroundImage, md: backgroundImage }}
         bgRepeat={'no-repeat'}
         bgSize={'cover'}
         bgPosition={'center'}

--- a/frontend/src/common-components/layout/AppBackground.tsx
+++ b/frontend/src/common-components/layout/AppBackground.tsx
@@ -6,16 +6,18 @@ export const AppBackground: FC<PropsWithChildren> = ({ children }) => {
   const config = useConfigContext()
   const textColor = useColorModeValue(config.components.style.lightTextColor, config.components.style.darkTextColor)
   const background = useColorModeValue(config.components.style.lightBackgroundColor, config.components.style.darkBackgroundColor)
-  let backgroundImage = useColorModeValue(
+  let backgroundImageData: [string, string] = [
     `url(${config.components.style.lightBackgroundUrl})`,
     `url(${config.components.style.darkBackgroundUrl})`
-  )
+  ];
 
   if (window.innerWidth <= 768)
-    backgroundImage = useColorModeValue(
+    backgroundImageData = [
       `url(${config.components.style.lightMobileBackgroundUrl})`,
       `url(${config.components.style.darkMobileBackgroundUrl})`
-    )
+    ];
+
+  const backgroundImage = useColorModeValue(...backgroundImageData)
 
   return (
     <>

--- a/frontend/src/common-components/layout/AppBackground.tsx
+++ b/frontend/src/common-components/layout/AppBackground.tsx
@@ -6,10 +6,17 @@ export const AppBackground: FC<PropsWithChildren> = ({ children }) => {
   const config = useConfigContext()
   const textColor = useColorModeValue(config.components.style.lightTextColor, config.components.style.darkTextColor)
   const background = useColorModeValue(config.components.style.lightBackgroundColor, config.components.style.darkBackgroundColor)
-  const backgroundImage = useColorModeValue(
+  let backgroundImage = useColorModeValue(
     `url(${config.components.style.lightBackgroundUrl})`,
     `url(${config.components.style.darkBackgroundUrl})`
   )
+
+  if (window.innerWidth <= 768)
+    backgroundImage = useColorModeValue(
+      `url(${config.components.style.lightMobileBackgroundUrl})`,
+      `url(${config.components.style.darkMobileBackgroundUrl})`
+    )
+
   return (
     <>
       <Box


### PR DESCRIPTION
added quick fix to use mobile background on smaller screens

This might not be the best way to do it, since the screen's size is only checked once, on the component's load.  
A resize event handler could be added to make it responsive, but I'm not sure if that's needed.