### PR TITLE
Update release trigger to manual or tag, tag image with version

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,7 +34,9 @@ jobs:
 
       - name: Tag image with version
         if: ${{ startsWith(github.ref, 'refs/tags/v') }} # if this workflow was triggered by a new tag starting with "v"
-        run: docker image tag ${{ secrets.DOCKER_REGISTRY_URL }}/cmsch:release ${{ secrets.DOCKER_REGISTRY_URL }}/cmsch:${{ github.ref_name }}
+        run: docker image tag ${{ secrets.DOCKER_REGISTRY_URL }}/cmsch:release ${{ secrets.DOCKER_REGISTRY_URL }}/cmsch:"$GITHUB_REF_NAME"
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
 
       - name: Push OCI Image
         run: docker image push --all-tags ${{ secrets.DOCKER_REGISTRY_URL }}/cmsch

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,6 +17,8 @@ jobs:
           persist-credentials: false
 
       - name: Set up Docker Buildx
+        with:
+          cache-binary: false
         uses: docker/setup-buildx-action@v1
 
       - name: Login to Docker Registry

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,9 +1,10 @@
-name: Build and Push Docker Image
+name: Build and Push Release Docker Image
 
 on:
+  workflow_dispatch: # allow manually running this workflow
   push:
-    branches:
-      - master
+    tags:
+      - v*
 
 jobs:
   build-and-push-release:
@@ -31,8 +32,12 @@ jobs:
           arguments: clean bootBuildImage --imageName=${{ secrets.DOCKER_REGISTRY_URL }}/cmsch:release
           build-root-directory: backend
 
+      - name: Tag image with version
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }} # if this workflow was triggered by a new tag starting with "v"
+        run: docker image tag ${{ secrets.DOCKER_REGISTRY_URL }}/cmsch:release ${{ secrets.DOCKER_REGISTRY_URL }}/cmsch:${{ github.ref_name }}
+
       - name: Push OCI Image
-        run: docker push ${{ secrets.DOCKER_REGISTRY_URL }}/cmsch:release
+        run: docker image push --all-tags ${{ secrets.DOCKER_REGISTRY_URL }}/cmsch
 
       - name: Logout from Docker Registry
         run: docker logout ${{ secrets.DOCKER_REGISTRY_URL }}


### PR DESCRIPTION
Release docker images will now only be built when manually triggered or when creating a version tag.

When using a tag starting with `v`, the image will be tagged with it.