### PR TITLE
Fix required option in INJECT_* type form fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,20 @@ Once created, edit the `CMSchApplication` Run Configuration's Spring Boot Active
 4. Navigate to `Project Settings` > `Cloud Messaging` and scroll down to `Web Push certificates`
 5. If there is no key, click on `Generate key pair`. Copy the value from `Key pair` column and set `VITE_FIREBASE_WEB_PUSH_PUBLIC_KEY` to it.
 
+## Contributing
+
+Follow the [instructions by Samu](https://gist.github.com/Tschonti/4397e43fef11895235e25c46ae0ed65e#workflow-) with the following differences:
+- Pull requests will be squash merged, so keep them small and focused. When merged, the commits on your branch will get replaced by a single commit on the main branch. A good rule of thumb is to make sure the resulting squashed commit can be reverted without affecting unrelated parts of the codebase.
+- When there are conflicts with the main branch, rebase your feature branch onto main (`git fetch && git rebase origin/main`), fix the conflicts, **commit**, then force push the updated branch (`git push --force`).
+- To make it easier to review your pull request, consider cleaning up the commits with `git rebase --interactive`. You may also use `git commit --amend` to add the currently staged changes to the last commit instead of creating a new commit.
+
+> [!note]
+>  After using either of these you will have to use `git push --force` to allow pushing modified history to GitHub.
+
+- Commit messages should follow the rules outlined [here](https://cbea.ms/git-commit/). As this project is not versioned, [conventional commits](https://conventionalcommits.org) don't have too many benefits, so instead let's keep things consistent.
+
+
+
 ## Sponsors
 
 <a href="https://vercel.com?utm_source=kir-dev&utm_campaign=oss"><img src="client/public/img/powered-by-vercel.svg" height="46" /></a>

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -90,7 +90,7 @@ tasks.withType<KotlinCompile> {
 
 tasks.getByName<org.springframework.boot.gradle.tasks.bundling.BootBuildImage>("bootBuildImage") {
     buildpacks = listOf("gcr.io/paketo-buildpacks/adoptium", "urn:cnb:builder:paketo-buildpacks/java")
-    builder = "paketobuildpacks/builder-noble-java-tiny"
+    builder = "paketobuildpacks/builder-jammy-base"
     environment = mapOf(
         "BP_NATIVE_IMAGE" to "false",
         "CDS_TRAINING_JAVA_TOOL_OPTIONS" to "-Dspring.profiles.include=prewarm",

--- a/backend/src/main/resources/templates/component/details/form-editor.html
+++ b/backend/src/main/resources/templates/component/details/form-editor.html
@@ -275,10 +275,16 @@
                 const defaultValue = document.getElementById(`${property}_${id}_defaultValue`).value;
                 const values = document.getElementById(`${property}_${id}_values`).value;
                 const note = document.getElementById(`${property}_${id}_note`).value;
-                const required = document.getElementById(`${property}_${id}_required`).checked;
+                let required = document.getElementById(`${property}_${id}_required`).checked;
                 const permanent = document.getElementById(`${property}_${id}_permanent`).checked;
 
                 if (fieldName !== null && label !== null && type !== null && fieldName !== '') {
+                    // This may not be a final fix, since the option is displayed in the select,
+                    // but the value is not saved as the user expects it to be
+                    // Will avoid the frontend error for now
+                    if (type.startsWith('INJECT_'))
+                        required = false;
+
                     result.push({
                         fieldName : fieldName,
                         label : label,

--- a/backend/src/main/resources/templates/component/details/form-editor.html
+++ b/backend/src/main/resources/templates/component/details/form-editor.html
@@ -107,11 +107,11 @@
                             <span class="note">A mező alatt megjelenő szöveg.</span>
                         </div>
 
-                        <div class="field-group">
+                        <div class="field-group" style='${field.type.startsWith('INJECT_') ? 'display:none' : ''}'>
                             <label for="${property}_${id}_required">Kötelező kitölteni</label>
                             <div style="clear:both"></div>
                             <label class="switch">
-                                <input type="checkbox" id="${property}_${id}_required" ${field.required ? 'checked' : ''} onchange="saveField('${property}')" />
+                                <input type="checkbox" id="${property}_${id}_required" ${field.required && !field.type.startsWith('INJECT_')? 'checked' : ''} onchange="saveField('${property}')" ${field.type.startsWith('INJECT_') ? 'disabled' : ''} />
                                 <span class="slider"></span>
                             </label><br/>
                         </div>
@@ -275,16 +275,21 @@
                 const defaultValue = document.getElementById(`${property}_${id}_defaultValue`).value;
                 const values = document.getElementById(`${property}_${id}_values`).value;
                 const note = document.getElementById(`${property}_${id}_note`).value;
-                let required = document.getElementById(`${property}_${id}_required`).checked;
+                let required = document.getElementById(`${property}_${id}_required`);
                 const permanent = document.getElementById(`${property}_${id}_permanent`).checked;
 
-                if (fieldName !== null && label !== null && type !== null && fieldName !== '') {
-                    // This may not be a final fix, since the option is displayed in the select,
-                    // but the value is not saved as the user expects it to be
-                    // Will avoid the frontend error for now
-                    if (type.startsWith('INJECT_'))
-                        required = false;
+                if (type.startsWith('INJECT_')) {
+                    required.checked = false;
+                    required.disabled = true;
+                    required.parentElement.parentElement.style.display = 'none';
+                } else {
+                    required.disabled = false;
+                    required.parentElement.parentElement.style.display = 'block';
+                }
 
+                required = required.checked
+
+                if (fieldName !== null && label !== null && type !== null && fieldName !== '') {
                     result.push({
                         fieldName : fieldName,
                         label : label,

--- a/frontend/src/pages/form/components/autoFormField.tsx
+++ b/frontend/src/pages/form/components/autoFormField.tsx
@@ -27,6 +27,9 @@ export const AutoFormField = ({ fieldProps, control, disabled, submittedValue }:
     else defaultValue = ''
   }
 
+  if (fieldProps.type.startsWith('INJECT_'))
+    fieldProps.required = false
+
   const {
     field,
     fieldState: { error }

--- a/frontend/src/pages/form/components/autoFormField.tsx
+++ b/frontend/src/pages/form/components/autoFormField.tsx
@@ -17,6 +17,7 @@ interface AutoFormFieldProps {
 export const AutoFormField = ({ fieldProps, control, disabled, submittedValue }: AutoFormFieldProps) => {
   const selectValues = fieldProps.values.split(',').map((opt) => opt.trim())
   let defaultValue = isCheckbox(fieldProps.type) ? fieldProps.defaultValue === 'true' : fieldProps.defaultValue
+  let requiredValue = fieldProps.required
 
   if (submittedValue) {
     if (isCheckbox(fieldProps.type)) defaultValue = submittedValue === 'true'
@@ -28,7 +29,7 @@ export const AutoFormField = ({ fieldProps, control, disabled, submittedValue }:
   }
 
   if (fieldProps.type.startsWith('INJECT_'))
-    fieldProps.required = false
+    requiredValue = false
 
   const {
     field,
@@ -39,7 +40,7 @@ export const AutoFormField = ({ fieldProps, control, disabled, submittedValue }:
     defaultValue: defaultValue,
     rules: {
       required: {
-        value: fieldProps.required || fieldProps.type === FormFieldVariants.MUST_AGREE,
+        value: requiredValue || fieldProps.type === FormFieldVariants.MUST_AGREE,
         message: 'Ez a mező kötelező!'
       },
       pattern: { value: new RegExp(fieldProps.formatRegex), message: 'Ellenőrizze a formátumot!' }


### PR DESCRIPTION
The current code will avoid saving the 'required' option as 'true', thereby avoiding the error message in the frontend saying, 'you need to fill out every required field'.