### PR TITLE
Move api call out of transaction to prevent calling it multiple times

### DIFF
--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/form/FormApiController.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/form/FormApiController.kt
@@ -1,11 +1,11 @@
 package hu.bme.sch.cmsch.component.form
 
 import com.fasterxml.jackson.annotation.JsonView
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import hu.bme.sch.cmsch.dto.FullDetails
 import hu.bme.sch.cmsch.dto.Preview
 import hu.bme.sch.cmsch.model.RoleType
+import hu.bme.sch.cmsch.model.UserEntity
 import hu.bme.sch.cmsch.util.getUserEntityFromDatabaseOrNull
 import hu.bme.sch.cmsch.util.getUserOrNull
 import org.slf4j.LoggerFactory
@@ -31,28 +31,54 @@ class FormApiController(
 
     @JsonView(FullDetails::class)
     @GetMapping("/form/{path}")
-    fun specificForm(@PathVariable path: String, auth: Authentication?): FormView {
+    fun getForm(@PathVariable path: String, auth: Authentication?): FormView {
         val user = auth?.getUserOrNull()
-
         return formService.fetchForm(user, path)
     }
 
     @PostMapping("/form/{path}")
-    fun fillOutForm(@PathVariable path: String, auth: Authentication?, @RequestBody data: Map<String, String>): FormSubmissionStatus {
+    fun fillOutForm(
+        @PathVariable path: String,
+        auth: Authentication?,
+        @RequestBody data: Map<String, String>
+    ): FormSubmissionStatus {
         val user = auth?.getUserEntityFromDatabaseOrNull()
-
-        val (status, exitId) = formService.submitForm(user, path, data, false)
-        log.info("User '{}' filling out form '{}' status: {} exitId: {} data: {}", user?.userName, path, status, exitId, objectMapper.writeValueAsString(data))
-        return status
+        return submitForm(false, path, user, data)
     }
 
     @PutMapping("/form/{path}")
-    fun updateForm(@PathVariable path: String, auth: Authentication?, @RequestBody data: Map<String, String>): FormSubmissionStatus {
+    fun updateForm(
+        @PathVariable path: String,
+        auth: Authentication?,
+        @RequestBody data: Map<String, String>
+    ): FormSubmissionStatus {
         val user = auth?.getUserEntityFromDatabaseOrNull()
             ?: return FormSubmissionStatus.FORM_NOT_AVAILABLE
+        return submitForm(true, path, user, data)
+    }
 
-        val (status, exitId) = formService.submitForm(user, path, data, true)
-        log.info("User '{}' updating form '{}' status: {} exitId: {} data: {}", user.userName, path, status, exitId, objectMapper.writeValueAsString(data))
+    private fun submitForm(
+        update: Boolean,
+        path: String,
+        user: UserEntity?,
+        data: Map<String, String>
+    ): FormSubmissionStatus {
+        val (status, exitId, result) = formService.submitForm(user, path, data, update)
+        log.info(
+            "User '{}' {} form '{}' status: {} exitId: {} data: {}",
+            user?.userName,
+            if (update) "updating" else "filling out",
+            path,
+            status,
+            exitId,
+            objectMapper.writeValueAsString(data)
+        )
+
+        if (result != null) {
+            runCatching {
+                formService.sendConfirmationEmail(result.form, result.email, update, result.submission)
+            }.exceptionOrNull()?.let { log.error("Failed to send email", it) }
+        }
         return status
     }
 

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/form/ResponseEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/form/ResponseEntity.kt
@@ -92,14 +92,6 @@ data class ResponseEntity(
 
     @field:JsonView(value = [ Edit::class ])
     @Column(nullable = false)
-    @ColumnDefault("false")
-    @property:GenerateInput(type = INPUT_TYPE_SWITCH, order = 7, label = "E-mail értesítés elküldve")
-    @property:GenerateOverview(columnName = "E-mail értesítés elküldve", order = 4, centered = true, renderer = OVERVIEW_TYPE_BOOLEAN)
-    @property:ImportFormat
-    var sentConfirmation: Boolean = false,
-
-    @field:JsonView(value = [ Edit::class ])
-    @Column(nullable = false)
     @property:GenerateInput(type = INPUT_TYPE_DATE, order = 6, label = "Fizetve ekkor", enabled = false, ignore = true)
     @property:GenerateOverview(visible = false)
     @property:ImportFormat

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/config/TestConfig.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/config/TestConfig.kt
@@ -170,7 +170,6 @@ open class TestConfig(
             now,
             0,
             false,
-            false,
             0,
             false,
             "",


### PR DESCRIPTION
When a lot of concurrent calls hit the endpoint, some of the users got multiple emails, because some of the transactions got rolled back and retried. In this PR I moved the email sending API call outside of the database transaction