### PR TITLE
Expose IDs for events and news

### DIFF
--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/event/EventEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/event/EventEntity.kt
@@ -23,7 +23,7 @@ import org.springframework.core.env.Environment
 data class EventEntity(
     @Id
     @GeneratedValue
-    @field:JsonView(value = [ Edit::class ])
+    @field:JsonView(value = [ Edit::class, Preview::class, FullDetails::class ])
     @Column(nullable = false)
     @property:GenerateInput(type = InputType.HIDDEN, visible = true, ignore = true)
     @property:GenerateOverview(renderer = OverviewType.ID, columnName = "ID", order = -1)

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/news/NewsEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/news/NewsEntity.kt
@@ -23,7 +23,7 @@ import org.springframework.core.env.Environment
 data class NewsEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
-    @field:JsonView(value = [ Edit::class ])
+    @field:JsonView(value = [ Edit::class, Preview::class, FullDetails::class ])
     @Column(nullable = false)
     @property:GenerateInput(type = InputType.HIDDEN, visible = true, ignore = true)
     @property:GenerateOverview(renderer = OverviewType.ID, columnName = "ID", order = -1)


### PR DESCRIPTION
Needed for tracking by StartSCH.

This should add the `id` field to the entities returned by `/api/news` and `/api/events`.