### PR TITLE
feat: detailed race statistics on profile

### DIFF
--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/profile/ProfileService.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/profile/ProfileService.kt
@@ -9,9 +9,8 @@ import hu.bme.sch.cmsch.component.groupselection.GroupSelectionComponent
 import hu.bme.sch.cmsch.component.location.LocationService
 import hu.bme.sch.cmsch.component.login.CmschUser
 import hu.bme.sch.cmsch.component.login.LoginComponent
-import hu.bme.sch.cmsch.component.race.FreestyleRaceEntryDto
 import hu.bme.sch.cmsch.component.race.RaceService
-import hu.bme.sch.cmsch.component.race.RaceView
+import hu.bme.sch.cmsch.component.race.RaceStatsView
 import hu.bme.sch.cmsch.component.riddle.RiddleBusinessLogicService
 import hu.bme.sch.cmsch.component.task.TasksService
 import hu.bme.sch.cmsch.component.token.ALL_TOKEN_TYPE
@@ -64,8 +63,7 @@ class ProfileService(
         val tokenCategoryToDisplay = tokenComponent.map { it.collectRequiredType }.orElse(ALL_TOKEN_TYPE)
         val incompleteTasks = tasksService.map { it.getTasksThatNeedsToBeCompleted(user) }.orElse(null)
 
-        val raceView: RaceView? = raceService.map { it.getViewForUsers(user) }.orElse(null)
-        val freestyleRaceView: FreestyleRaceEntryDto? = raceService.map { it.getFreestyleEntryOfUser(user.id) }.orElse(null)
+        val raceStats: RaceStatsView? = raceService.map { it.getRaceStats(user) }.orElse(null)
 
         return ProfileView(
             loggedIn = true,
@@ -114,10 +112,7 @@ class ProfileService(
             }.orElse(null),
 
             // Race component
-            racePlacement = raceView?.place,
-            raceStat = raceView?.bestTime,
-            freestyleRaceDescription = freestyleRaceView?.description,
-            freestyleRaceStat = freestyleRaceView?.time,
+            raceStats = raceStats,
 
             // Locations component
             locations = profileComponent.showGroupLeadersLocations.mapIfTrue { fetchLocations(group).orElse(null) },

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/profile/ProfileView.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/profile/ProfileView.kt
@@ -3,6 +3,7 @@ package hu.bme.sch.cmsch.component.profile
 import com.fasterxml.jackson.annotation.JsonView
 import hu.bme.sch.cmsch.component.debt.DebtDto
 import hu.bme.sch.cmsch.component.leaderboard.LeaderBoardEntry
+import hu.bme.sch.cmsch.component.race.RaceStatsView
 import hu.bme.sch.cmsch.component.token.TokenDto
 import hu.bme.sch.cmsch.dto.FullDetails
 import hu.bme.sch.cmsch.model.GuildType
@@ -79,21 +80,9 @@ data class ProfileView(
     @field:JsonView(FullDetails::class)
     val completedTaskCount: Int? = null,
 
-    // Race placement
+    // Race stats
     @field:JsonView(FullDetails::class)
-    val racePlacement: Int? = null,
-
-    // Race stat given in seconds
-    @field:JsonView(FullDetails::class)
-    val raceStat: Float? = null,
-
-    // Freestyle (funky) race description
-    @field:JsonView(FullDetails::class)
-    val freestyleRaceDescription: String? = null,
-
-    // Freestyle (funky) race stat given in seconds
-    @field:JsonView(FullDetails::class)
-    val freestyleRaceStat: Float? = null,
+    val raceStats: RaceStatsView? = null,
 
     @field:JsonView(FullDetails::class)
     val profileIsComplete: Boolean? = null,

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/race/RaceService.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/race/RaceService.kt
@@ -8,6 +8,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import kotlin.jvm.optionals.getOrNull
+import kotlin.math.pow
+import kotlin.math.sqrt
 
 const val DEFAULT_CATEGORY = ""
 
@@ -270,23 +272,38 @@ open class RaceService(
             .sortedByDescending { it.time }
     }
 
-    /**
-     * Shorthand query of freestyle record of the user with the given ID.
-     * This does not query all the users, just the user requested.
-     * @return FreestyleRaceEntryDto of the user with the given id, or null if not present.
+    /***
+     * Gets relevant statistics about race entries of the given user
+     * @param CmschUser whose stats we want to get
+     * @return RaceStatsView of the user, or null if the user has no submissions
      */
     @Transactional(readOnly = true)
-    open fun getFreestyleEntryOfUser(userId: Int): FreestyleRaceEntryDto? {
-        val entity = freestyleRaceRecordRepository.findByUserId(userId)
+    open fun getRaceStats(user: CmschUser): RaceStatsView? {
+        val records: List<RaceRecordEntity> = raceRecordRepository.findAll().sortedBy { it.time }
+        var userRecords = records.filter { it.userId == user.id }
 
-        return entity?.let {
-            FreestyleRaceEntryDto(
-                id = it.id,
-                name = it.userName,
-                groupName = it.groupName,
-                time = it.time,
-                description = it.description,
-            )
-        }
+        if( userRecords.isEmpty() ) return null
+
+        val bestTime = records.minBy { it.time }.time
+        val placement = records.indexOfFirst { it.userId == user.id } + 1
+
+        val timesParticipated = userRecords.count()
+
+        val averageTime = userRecords.map { it.time }.average().toFloat()
+
+        val deviation = sqrt(userRecords.map { it.time }.map { (it - averageTime).pow(2) }.average()).toFloat()
+
+        // kcal of 0.5l of Soproni Lager
+        val kcalPerPortion = 164
+        val kCaloriesPerSecond = kcalPerPortion / bestTime
+
+        return RaceStatsView(
+            bestTime = bestTime,
+            placement = placement,
+            timesParticipated = timesParticipated,
+            averageTime = averageTime,
+            deviation = deviation,
+            kCaloriesPerSecond = kCaloriesPerSecond
+        )
     }
 }

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/race/RaceStatsView.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/race/RaceStatsView.kt
@@ -1,0 +1,31 @@
+package hu.bme.sch.cmsch.component.race
+
+import com.fasterxml.jackson.annotation.JsonView
+import hu.bme.sch.cmsch.dto.FullDetails
+
+
+data class RaceStatsView(
+    // The best time in seconds
+    @field:JsonView(FullDetails::class)
+    val bestTime: Float,
+
+    // The placement on the uncategorized leaderboard
+    @field:JsonView(FullDetails::class)
+    val placement: Int,
+
+    // The amount of submissions made
+    @field:JsonView(FullDetails::class)
+    val timesParticipated: Int,
+
+    // Average of times
+    @field:JsonView(FullDetails::class)
+    val averageTime: Float,
+
+    // Deviation of times
+    @field:JsonView(FullDetails::class)
+    val deviation: Float,
+
+    // kcal consumed per second, using the best time as reference
+    @field:JsonView(FullDetails::class)
+    val kCaloriesPerSecond: Float,
+)

--- a/frontend/src/pages/profile/profile.page.tsx
+++ b/frontend/src/pages/profile/profile.page.tsx
@@ -68,6 +68,8 @@ const ProfilePage = () => {
     return <Navigate replace to="/" />
   }
 
+  const raceStats = profile?.raceStats
+
   return (
     <CmschPage loginRequired>
       <Helmet title={component.title} />
@@ -158,27 +160,37 @@ const ProfilePage = () => {
       )}
       {(component.showTasks || component.showRiddles || component.showTokens) && <Divider my={8} borderWidth={2} />}
 
-      {component.showRaceStats && profile?.raceStat && (
-        <Grid templateColumns={{ base: '1fr 1fr', sm: '1fr 2fr', md: '1fr 3fr' }}>
-          <Text as="i">Mérés eredmény: </Text>
-          <Text>
-            <Text as="b">{profile?.raceStat}s</Text>
-            {profile.racePlacement && <Text as="b" fontStyle="italic">{` (${profile.racePlacement}. helyezett)`}</Text>}
-          </Text>
-        </Grid>
-      )}
-      {component.showRaceStats && profile?.freestyleRaceStat && (
-        <Grid templateColumns={{ base: '1fr 1fr', sm: '1fr 2fr', md: '1fr 3fr' }}>
-          <Text as="i" whiteSpace="nowrap">
-            Funky Mérés:{' '}
-          </Text>
-          <Text>
-            <Text as="b" whiteSpace="nowrap">
-              {profile.freestyleRaceStat}s
+      {component.showRaceStats && raceStats && (
+        <>
+          <Heading as="h2" size="md" fontWeight="bold" textAlign="center" textDecoration="underline" pb={2}>
+            Sörmérés
+          </Heading>
+
+          <Text fontWeight="bold" textAlign="center">{`Legjobb idő: ${raceStats.bestTime}s`}</Text>
+          <Text fontWeight="bold" fontStyle="italic" textAlign="center" pb={2}>{`${raceStats.placement}. helyezett`}</Text>
+
+          <Grid templateColumns={'1fr 1fr'} mx="30%" columnGap={5}>
+            <Text fontStyle="italic" textAlign="right">
+              Mérések száma:
             </Text>
-            {profile.freestyleRaceDescription && <Text as="b" fontStyle="italic">{` (${profile.freestyleRaceDescription})`}</Text>}
-          </Text>
-        </Grid>
+            <Text>{` ${raceStats.timesParticipated}`}</Text>
+
+            <Text fontStyle="italic" textAlign="right">
+              Átlag idő:
+            </Text>
+            <Text>{`${raceStats.averageTime}s`}</Text>
+
+            <Text fontStyle="italic" textAlign="right">
+              Szórás:
+            </Text>
+            <Text>{`${raceStats.deviation}s`}</Text>
+
+            <Text fontStyle="italic" textAlign="right">
+              Kalória/másodperc:
+            </Text>
+            <Text>{`${raceStats.kCaloriesPerSecond} kcal/s`}</Text>
+          </Grid>
+        </>
       )}
 
       <Flex justify="center" alignItems="center" flexWrap="wrap">

--- a/frontend/src/util/views/profile.view.ts
+++ b/frontend/src/util/views/profile.view.ts
@@ -34,10 +34,7 @@ export interface ProfileView {
   submittedTaskCount?: number
   completedTaskCount?: number
 
-  racePlacement?: number
-  raceStat?: number
-  freestyleRaceDescription?: string
-  freestyleRaceStat?: number
+  raceStats?: RaceStatsView
 
   locations?: GroupMemberLocationView[]
   debts?: DebtView[]
@@ -48,6 +45,15 @@ export interface ProfileView {
 
   groupMessage?: string
   userMessage?: string
+}
+
+export interface RaceStatsView {
+  bestTime: number
+  placement: number
+  timesParticipated: number
+  averageTime: number
+  deviation: number
+  kCaloriesPerSecond: number
 }
 
 //cannot compare roles if the enums values are strings use the RoleType[role] syntax


### PR DESCRIPTION
Closes #967 

As requested by the organizers, I added a few more statistics to the page. They also declared that displaying the freestyle race statistics were unnecessary, so I removed it. It looks like this now:
<img width="1670" height="885" alt="image" src="https://github.com/user-attachments/assets/3feaf112-e19d-43db-8aaf-2da409ac1877" />
 