### PR TITLE
fixed an oversight with the best time and placement evaluation

### DIFF
--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/race/RaceService.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/race/RaceService.kt
@@ -279,13 +279,18 @@ open class RaceService(
      */
     @Transactional(readOnly = true)
     open fun getRaceStats(user: CmschUser): RaceStatsView? {
+
+        // All records
         val records: List<RaceRecordEntity> = raceRecordRepository.findAll().sortedBy { it.time }
+
+        // All the records of this user
         var userRecords = records.filter { it.userId == user.id }
-
         if( userRecords.isEmpty() ) return null
+        val bestTime = userRecords.minBy { it.time }.time
 
-        val bestTime = records.minBy { it.time }.time
-        val placement = records.indexOfFirst { it.userId == user.id } + 1
+        // Best records of all users.
+        val bestTimes = records.groupBy { it.userId }.map { it.value.first() }.sortedBy { it.time } // Sort might be unnecessary, but just to be safe
+        val placement = bestTimes.indexOfFirst { it.userId == user.id } + 1
 
         val timesParticipated = userRecords.count()
 


### PR DESCRIPTION
I mistakenly checked the best time of all users, for the user, therefore it always returned the globally best time.

I also accidentally checked the placement, based on all records in the database (If person A had 2 records where both had better time than you, it accounted both for the placement)

Both these errors should be fixed now