### PR TITLE
feat: various labels and race stats modifications

### DIFF
--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/race/RaceEntryDto.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/race/RaceEntryDto.kt
@@ -37,9 +37,14 @@ data class RaceEntryDto(
     var email: String = "",
 
     @field:JsonView(FullDetails::class)
-    @property:GenerateOverview(columnName = "Címke", order = 6)
+    @property:GenerateOverview(columnName = "Címke", order = 5)
     @property:ImportFormat
     var label: String = "",
+
+    @field:JsonView(FullDetails::class)
+    @property:GenerateOverview(columnName = "Címke színe", order = 6)
+    @property:ImportFormat
+    var labelColor: String? = "",
 
     ) : ManagedEntity {
 

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/race/RaceRecordEntity.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/race/RaceRecordEntity.kt
@@ -28,7 +28,7 @@ data class RaceRecordEntity(
 
     @Column(nullable = false)
     @field:JsonView(value = [ Edit::class ])
-    @property:GenerateInput(order = 2, label = "Kategória", type = InputType.ENTITY_SELECT,
+    @property:GenerateInput(order = 1, label = "Kategória", type = InputType.ENTITY_SELECT,
         entitySource = "RaceCategoryEntity", note = "Az üres az alapértelmezett kategória")
     @property:GenerateOverview(columnName = "Kategória", order = 1)
     @property:ImportFormat
@@ -78,10 +78,21 @@ data class RaceRecordEntity(
 
     @Column(nullable = false)
     @field:JsonView(value = [ Edit::class, Preview::class, FullDetails::class ])
-    @property:GenerateInput(order = 7, label = "Címke", note = "Név melletti címke, pl: Gólya, Lány etc.")
+    @property:GenerateInput(order = 6, label = "Címke", note = "Név melletti címke, pl: Gólya, Lány etc.")
     @property:GenerateOverview(columnName = "Címke", order = 6)
     @property:ImportFormat
     var label: String = "",
+
+    @Column(nullable = true, columnDefinition = "TEXT")
+    @field:JsonView(value = [Edit::class, Preview::class, FullDetails::class])
+    @property:GenerateInput(
+        order = 7,
+        type = InputType.COLOR,
+        label = "Szín",
+        note = "A címke színe hex kódban megadva. Ha üresen hagyod, akkor az oldal színét fogja használni.",
+    )
+    @property:ImportFormat
+    var labelColor: String? = "",
 
 ) : ManagedEntity, Duplicatable {
 

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/race/RaceService.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/race/RaceService.kt
@@ -112,6 +112,7 @@ open class RaceService(
                     submission.value.minOf { it.time },
                     email = "",
                     submission.value.first().label,
+                    submission.value.first().labelColor
                 )
             }
             .sortedBy { it.time }
@@ -126,6 +127,7 @@ open class RaceService(
                     submission.value.maxOf { it.time },
                     email = "",
                     submission.value.first().label,
+                    submission.value.first().labelColor
                 )
             }
             .sortedByDescending { it.time }
@@ -223,6 +225,7 @@ open class RaceService(
                     submission.value.minOf { it.time },
                     email,
                     submission.value.first().label,
+                    submission.value.first().labelColor
                 )
             }
             .sortedBy { it.time }
@@ -240,6 +243,7 @@ open class RaceService(
                     submission.value.maxOf { it.time },
                     email,
                     submission.value.first().label,
+                    submission.value.first().labelColor
                 )
             }
             .sortedByDescending { it.time }

--- a/frontend/src/common-components/CollapsableTableRow.tsx
+++ b/frontend/src/common-components/CollapsableTableRow.tsx
@@ -1,5 +1,5 @@
 import { ChevronDownIcon, ChevronUpIcon } from '@chakra-ui/icons'
-import { Box, Link as ChakraLink, Grid, GridItem, HStack, useDisclosure } from '@chakra-ui/react'
+import { Box, Link as ChakraLink, Grid, GridItem, Stack, useDisclosure } from '@chakra-ui/react'
 import { Fragment } from 'react'
 import { Link } from 'react-router'
 import TeamLabel from '../pages/teams/components/TeamLabel.tsx'
@@ -37,14 +37,12 @@ export const CollapsableTableRow = ({
   const outerColTemplate: string[] = []
   if (!categorized) outerColTemplate.push('[place] auto')
   outerColTemplate.push('[name] 1fr')
-  if (data.label) outerColTemplate.push('[label] 1fr')
   if (showGroup) outerColTemplate.push('[group] 1fr')
   outerColTemplate.push('[score] auto [chevron] 20px')
 
   const innerColTemplate: string[] = []
   if (categorized) innerColTemplate.push('[place] auto')
   innerColTemplate.push('[name] 1fr [score] auto')
-  if (data.label) innerColTemplate.push('[label] 1fr')
   if (!categorized) innerColTemplate.push('[chevron] 20px')
   innerColTemplate.push('[end]')
 
@@ -63,9 +61,9 @@ export const CollapsableTableRow = ({
       >
         {!categorized && <GridItem>{data.position}.</GridItem>}
         <GridItem>
-          <HStack>
-            <Box>{data.name}</Box> {data.label && <TeamLabel name={data.label} />}
-          </HStack>
+          <Stack direction={['column', 'row']}>
+            <Box>{data.name}</Box> {data.label && <TeamLabel name={data.label} color={data.labelColor} />}
+          </Stack>
         </GridItem>
         {showGroup && data.groupName && (
           <GridItem gridColumn="group">

--- a/frontend/src/common-components/LeaderboardTable.tsx
+++ b/frontend/src/common-components/LeaderboardTable.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from '@chakra-ui/react'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useSearch } from '../util/useSearch'
 import { LeaderBoardItemView } from '../util/views/leaderBoardView'
 import { CollapsableTableRow } from './CollapsableTableRow'
@@ -26,14 +26,17 @@ export const LeaderBoardTable = ({
 }: LeaderboardTableProps) => {
   const dataWithPosition = useMemo(() => data.map((item, index) => ({ ...item, position: index + 1 })), [data])
 
-  const searchArgs = useSearch(
-    dataWithPosition,
-    (item, searchWord) =>
+  const searchFunc = useCallback((item: LeaderBoardItemView, searchWord: string) => {
+    return (
       (item.name.toLowerCase().includes(searchWord) ||
         item.groupName?.toLowerCase().includes(searchWord) ||
-        item.description?.toLowerCase().includes(searchWord)) ??
+        item.description?.toLowerCase().includes(searchWord) ||
+        item.label?.toLowerCase().includes(searchWord)) ??
       false
-  )
+    )
+  }, [])
+
+  const searchArgs = useSearch(dataWithPosition, searchFunc)
 
   return (
     <>

--- a/frontend/src/pages/profile/profile.page.tsx
+++ b/frontend/src/pages/profile/profile.page.tsx
@@ -161,7 +161,7 @@ const ProfilePage = () => {
           <Text fontWeight="bold" textAlign="center">{`Legjobb idő: ${raceStats.bestTime}s`}</Text>
           <Text fontWeight="bold" fontStyle="italic" textAlign="center" pb={2}>{`${raceStats.placement}. helyezett`}</Text>
 
-          <Grid templateColumns={'1fr 1fr'} mx="30%" columnGap={5}>
+          <Grid templateColumns={'1fr 1fr'} columnGap={5}>
             <Text fontStyle="italic" textAlign="right">
               Mérések száma:
             </Text>

--- a/frontend/src/pages/teams/components/TeamLabel.tsx
+++ b/frontend/src/pages/teams/components/TeamLabel.tsx
@@ -27,6 +27,8 @@ const LabelComponent = ({ name, color, darkColor }: { name: string; color: strin
       fontWeight="bold"
       fontSize={12}
       letterSpacing={1.2}
+      width="fit-content"
+      height="fit-content"
     >
       {name}
     </Box>

--- a/frontend/src/pages/teams/components/TeamListItem.tsx
+++ b/frontend/src/pages/teams/components/TeamListItem.tsx
@@ -1,5 +1,5 @@
 import { ChevronRightIcon } from '@chakra-ui/icons'
-import { Box, Heading, HStack, Image, Spacer, VStack } from '@chakra-ui/react'
+import { Box, Heading, HStack, Image, Spacer, Stack, VStack } from '@chakra-ui/react'
 import { Link } from 'react-router'
 import { useOpaqueBackground } from '../../../util/core-functions.util'
 import { AbsolutePaths } from '../../../util/paths'
@@ -26,13 +26,13 @@ export const TeamListItem = ({ team, detailEnabled = false }: TeamListItemProps)
       >
         <HStack spacing={4}>
           <VStack align="flex-start" overflow="hidden">
-            <HStack spacing={4} alignItems="baseline">
+            <Stack direction={['column', 'row']} spacing={[2, 4]} alignItems="baseline">
               <Heading as="h3" size="md" marginY={0} maxWidth="100%">
                 {team.name}
               </Heading>
               {team.labels &&
                 team.labels.map((label, index) => <TeamLabel name={label.name} color={label.color} desc={label.description} key={index} />)}
-            </HStack>
+            </Stack>
             {team.introduction && <Box>{team.introduction}</Box>}
           </VStack>
           <Spacer />

--- a/frontend/src/util/views/leaderBoardView.ts
+++ b/frontend/src/util/views/leaderBoardView.ts
@@ -13,6 +13,7 @@ export type LeaderBoardItemView = {
   description?: string
   score?: number
   label?: string
+  labelColor?: string
   items?: LeaderBoardDetail[]
   total?: number
   tokenRarities?: { [key: string]: number }


### PR DESCRIPTION
Added and fixed some very small requests and issues:

 - Added race entry label color. It is for now nullable so it doesn't break the prod db
 - Labels now go under the name, both at groups and race entries on mobile
 - (fix) You can now search between race labels again
 - (fix) Race stats was not centered on mobile