### PR TITLE
Changed useTime so that it gives back the time in seconds since the epoch

### DIFF
--- a/frontend/src/hooks/useDate.ts
+++ b/frontend/src/hooks/useDate.ts
@@ -18,6 +18,6 @@ export const useDate = (refreshIntervalMs?: number) => {
 }
 
 export const useTime = (refreshIntervalMs?: number) => {
-  const timeSupplier = useCallback(() => Date.now(), [])
+  const timeSupplier = useCallback(() => Date.now() / 1000, [])
   return useRefreshedInterval(timeSupplier, refreshIntervalMs)
 }


### PR DESCRIPTION
previously it was given in milliseconds since the epoch, but the task pages use it as if it were in seconds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated time handling to return Unix timestamps in seconds rather than milliseconds, ensuring consistent temporal data formats while maintaining refresh interval behavior and interface compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->