### PR TITLE
Use font in resources for exporting qrs

### DIFF
--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/token/QrExporterDashboard.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/token/QrExporterDashboard.kt
@@ -37,6 +37,7 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import javax.imageio.ImageIO
 import kotlin.math.max
+import org.slf4j.LoggerFactory
 
 private const val VIEW = "token-qr-export"
 
@@ -68,6 +69,22 @@ class QrExporterDashboard(
     adminMenuIcon = "qr_code",
     adminMenuPriority = 3
 ) {
+    companion object {
+        private val logger = LoggerFactory.getLogger(QrExporterDashboard::class.java)
+        private val renderFont: Font? = try {
+            val fontStream = QrExporterDashboard::class.java.getResourceAsStream("/OpenSans-Regular.ttf")
+            if (fontStream != null) {
+                Font.createFont(Font.TRUETYPE_FONT, fontStream)
+            } else {
+                logger.warn("OpenSans-Regular.ttf not found in resources")
+                null
+            }
+        } catch (e: Exception) {
+            logger.warn("Failed to load OpenSans-Regular.ttf font", e)
+            null
+        }
+    }
+
     private val permissionCard = DashboardPermissionCard(
         id = 1,
         permission = showPermission.permissionString,
@@ -213,7 +230,7 @@ class QrExporterDashboard(
             g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
             g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
 
-            val baseFont = Font("SansSerif", Font.PLAIN, 26)
+            val baseFont = renderFont?.deriveFont(26f) ?: Font(Font.SANS_SERIF, Font.PLAIN, 26)
 
             g.font = baseFont
             val fmTop = g.fontMetrics

--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/token/QrExporterDashboard.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/token/QrExporterDashboard.kt
@@ -72,10 +72,9 @@ class QrExporterDashboard(
     companion object {
         private val logger = LoggerFactory.getLogger(QrExporterDashboard::class.java)
         private val renderFont: Font? = try {
-            val fontStream = QrExporterDashboard::class.java.getResourceAsStream("/OpenSans-Regular.ttf")
-            if (fontStream != null) {
+            QrExporterDashboard::class.java.getResourceAsStream("/OpenSans-Regular.ttf")?.use { fontStream ->
                 Font.createFont(Font.TRUETYPE_FONT, fontStream)
-            } else {
+            } ?: run {
                 logger.warn("OpenSans-Regular.ttf not found in resources")
                 null
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QR export image text rendering by using a custom TrueType font when available.
  * Added a safe fallback to the default system font if the custom font can’t be loaded.
  * Font-loading problems are now logged to help diagnose rendering issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->