### PR TITLE
Changed renderer for properties of GradedTaskGroupDto to number

### DIFF
--- a/backend/src/main/kotlin/hu/bme/sch/cmsch/component/task/GradedTaskGroupDto.kt
+++ b/backend/src/main/kotlin/hu/bme/sch/cmsch/component/task/GradedTaskGroupDto.kt
@@ -12,13 +12,13 @@ data class GradedTaskGroupDto(
     @property:GenerateOverview(columnName = "Cím", order = 1)
     var taskName: String = "",
 
-    @property:GenerateOverview(columnName = "OK", order = 2, centered = true)
+    @property:GenerateOverview(renderer = OverviewType.NUMBER, columnName = "OK", order = 2, centered = true)
     var approved: Int = 0,
 
-    @property:GenerateOverview(columnName = "Nem OK", order = 3, centered = true)
+    @property:GenerateOverview(renderer = OverviewType.NUMBER, columnName = "Nem OK", order = 3, centered = true)
     var rejected: Int = 0,
 
-    @property:GenerateOverview(columnName = "Értékelésre vár", order = 4, centered = true)
+    @property:GenerateOverview(renderer = OverviewType.NUMBER, columnName = "Értékelésre vár", order = 4, centered = true)
     var notGraded: Int = 0
 
 ) : IdentifiableEntity


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the task group overview so approval and rejection counts now display consistently as numbers with centered alignment.
  * Kept the existing labels and ordering unchanged for a familiar layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->